### PR TITLE
Use GCS for binary publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,7 +89,7 @@ jobs:
         env:
           GOOS: ${{ matrix.platform.os }}
           GOARCH: ${{ matrix.platform.arch }}
-          VERSION: ${{ needs.set-version.outputs.version }}
+          VERSION: ${{ github.event.release.tag_name }}
         run: |
           # if pack is true, use build-and-pack target (which compresses the binary), otherwise use build target
           if [ "${{ matrix.platform.pack }}" = "true" ]; then
@@ -97,36 +97,63 @@ jobs:
           else
             make build
           fi
-      - name: Upload binary to GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-binaries:
+    name: Publish Binaries
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [build-binaries]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Authenticate to Google Cloud Storage
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: ${{ secrets.GC_TODO_GHA_SA }}
+          project_id: solo-public
+      - name: Set up Google Cloud SDK
+        uses: 'google-github-actions/setup-gcloud@v2'
+      - name: Publish Binaries to Google Cloud Storage
+        uses: 'google-github-actions/upload-cloud-storage@v2'
+        with:
+          path: '_output' # Publish the version folder to the bucket
+          destination: istio-usage-collector
+          parent: false
+          process_gcloudignore: false
+  
+  publish-release-metadata:
+    name: Publish Release Metadata
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [publish-binaries]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Authenticate to Google Cloud Storage
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: ${{ secrets.GC_TODO_GHA_SA }}
+          project_id: solo-public
+      - name: Set up Google Cloud SDK
+        uses: 'google-github-actions/setup-gcloud@v2'
+      - name: Set Up Release Metadata
+        shell: bash
         run: |
-          # Define binary path
-          BINARY_PATH="_output/${{ needs.set-version.outputs.version }}/istio-usage-collector-${{ matrix.platform.os }}-${{ matrix.platform.arch }}"
-          
-          # For Windows builds, the .exe extension is part of the filename
-          if [ "${{ matrix.platform.os }}" = "windows" ]; then
-            BINARY_PATH="${BINARY_PATH}.exe"
-          fi
+          mkdir -p _output/metadata
 
-          # Verify binary exists
-          if [ ! -f "$BINARY_PATH" ]; then
-            echo "::error::Binary not found at $BINARY_PATH"
-            ls -la _output/${{ needs.set-version.outputs.version }}/
-            exit 1
-          fi
+          # Set up the releases.txt file for the release
+          gsutil ls -d "gs://istio-usage-collector/v*" \
+            | sed 's,^gs://istio-usage-collector/,,;s,/$,,' \
+            | (echo "${{ github.event.release.tag_name }}"; cat) \
+            | sort -rV \
+            > "_output/metadata/releases.txt"
 
-          SHA256_PATH="${BINARY_PATH}.sha256"          
-          # Verify the checksum file exists
-          if [ ! -f "$SHA256_PATH" ]; then
-            echo "::error::Checksum file not found at $SHA256_PATH"
-            ls -la _output/${{ needs.set-version.outputs.version }}/
-            exit 1
-          fi
-
-          # Upload to release's assets
-          echo "Uploading $BINARY_PATH to release ${{ github.event.release.tag_name }}"
-          gh release upload ${{ github.event.release.tag_name }} "$BINARY_PATH" --clobber
-
-          echo "Uploading $SHA256_PATH to release ${{ github.event.release.tag_name }}"
-          gh release upload ${{ github.event.release.tag_name }} "$SHA256_PATH" --clobber
+          # Set up the install script
+          cp "./scripts/install.sh" "_output/metadata/install.sh"
+      - name: Upload Release Metadata
+        uses: 'google-github-actions/upload-cloud-storage@v2'
+        with:
+          path: '_output/metadata'
+          destination: istio-usage-collector
+          parent: false
+          process_gcloudignore: false
+          headers: |-
+            cache-control: no-cache, no-store, must-revalidate, max-age=0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Authenticate to Google Cloud Storage
         uses: 'google-github-actions/auth@v2'
         with:
-          credentials_json: ${{ secrets.GC_TODO_GHA_SA }}
+          credentials_json: ${{ secrets.ISTIO_USAGE_COLLECTOR }}
           project_id: solo-public
       - name: Set up Google Cloud SDK
         uses: 'google-github-actions/setup-gcloud@v2'

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ This data is collected into a JSON or YAML file that can be used for further ana
 
 ## Installation
 
+### Downloading release
+
+You can download the latest release for your system by passing
+```sh
+curl -sL https://storage.googleapis.com/istio-usage-collector/install.sh | sh -
+```
+
+You can also specify a release version, os, and arch to download specific version(s) by passing the relevant flags
+```sh
+curl -sL https://storage.googleapis.com/istio-usage-collector/install.sh | sh - -- --os darwin --arch arm64 --version latest
+```
+
 ### Building from source
 
 1. Clone the repository:

--- a/changelogs/v0.1.1.yaml
+++ b/changelogs/v0.1.1.yaml
@@ -1,0 +1,3 @@
+ci:
+- Publish binaries to Google Cloud Storage
+- Set up install script to easily download release binaries

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -22,17 +22,40 @@ if [ "${VERSION}" = "latest" ] || [ -z "${VERSION}" ]; then
   fi
   # Use the first line as the latest version
   VERSION=$(echo "$AVAILABLE_VERSIONS" | head -n1)
-  echo "Latest version is ${VERSION}"
+  echo "Latest version is: ${VERSION}"
 else
-  echo "Using specified version ${VERSION}"
+  echo "Using specified version: ${VERSION}"
 fi
 
-# TODO: Add note for windows users which will likely need to manually look into the bucket for their OS/arch
-OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
-if [ "$OS" != "darwin" ]; then
+
+# Get the OS of the machine
+# Use the $OSTYPE variable if available, otherwise use uname
+OS=
+echo "Using OSTYPE to determine OS: ${OSTYPE}"
+if [[ "$OSTYPE" == "msys"* || "$OSTYPE" == "cygwin"* || "$OSTYPE" == "mingw"* ]]; then
+  OS=windows
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  OS=darwin
+elif [[ "$OSTYPE" == "linux"* ]]; then
   OS=linux
+else
+  echo "Running on an unknown operating system"
 fi
 
+# If the OS is still not set (not found in the OSTYPE check), use uname to determine OS
+if [ -z "$OS" ]; then
+  echo "Using uname to determine OS"
+
+  OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  # if its cygwun, mysys, or mingw, set it to windows; otherwise, if its not darwin, set it to linux
+  if [ "$OS" = "cygwin" ] || [ "$OS" = "msys" ] || [ "$OS" = "mingw" ]; then
+    OS=windows
+  elif [ "$OS" != "darwin" ]; then
+    OS=linux
+  fi
+fi
+
+# Get the architecture of the machine
 if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
   GOARCH=arm64
 else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,110 @@
+#!/bin/sh
+set -eu
+
+DEFAULT_BUCKET="istio-usage-collector"
+
+# Allow user to override the version via environment variable
+VERSION="${VERSION:-}"
+GCS_BUCKET="${GCS_BUCKET:-$DEFAULT_BUCKET}"
+BINARY_NAME="istio-usage-collector"
+
+if [ "${VERSION}" = "latest" ] || [ -z "${VERSION}" ]; then
+  echo "Finding latest version..."
+  # Fetch available versions and filter out versions that contains a hyphen (e.g. -rc or -beta)
+  if ! AVAILABLE_VERSIONS=$(curl -fsSL https://storage.googleapis.com/"${GCS_BUCKET}"/releases.txt | grep -E -v '\-'); then
+    echo "Error: Could not fetch list of available versions from GCS." >&2
+    echo "Bucket: ${GCS_BUCKET}" >&2
+    exit 1
+  fi
+  if [ -z "$AVAILABLE_VERSIONS" ]; then
+    echo "Error: No stable versions found in releases.txt." >&2
+    exit 1
+  fi
+  # Use the first line as the latest version
+  VERSION=$(echo "$AVAILABLE_VERSIONS" | head -n1)
+  echo "Latest version is ${VERSION}"
+else
+  echo "Using specified version ${VERSION}"
+fi
+
+# TODO: Add note for windows users which will likely need to manually look into the bucket for their OS/arch
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+if [ "$OS" != "darwin" ]; then
+  OS=linux
+fi
+
+if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
+  GOARCH=arm64
+else
+  GOARCH=amd64
+fi
+
+echo "Detected OS: ${OS}, Arch: ${GOARCH}"
+
+filename="${BINARY_NAME}-${OS}-${GOARCH}"
+url="https://storage.googleapis.com/${GCS_BUCKET}/${VERSION}/${filename}"
+
+echo "Attempting to download ${BINARY_NAME} version ${VERSION} from ${url}"
+
+if ! curl --output /dev/null --silent --head --fail "${url}"; then
+  echo "Error: File not found at ${url}" >&2
+  echo "Please check the version, OS, or architecture." >&2
+  exit 1
+fi
+
+# Download binary
+echo "Downloading ${filename}..."
+if ! curl -fsSL -o "${filename}" "${url}"; then
+  echo "Error: Failed to download binary from ${url}" >&2
+  exit 1
+fi
+
+# Calculate local checksum
+echo "Calculating local checksum..."
+local_checksum=$(openssl dgst -sha256 "${filename}" | awk '{ print $2 }')
+
+# Fetch remote checksum content and validate
+echo "Fetching remote checksum..."
+if ! remote_checksum_content=$(curl -fsSL "${url}.sha256"); then
+    echo "Warning: Failed to fetch remote checksum file from ${url}.sha256. Skipping verification." >&2
+else
+    echo "Validating checksum..."
+    expected_checksum=$(echo "$remote_checksum_content" | awk '{ print $1 }')
+
+    if [ -z "$expected_checksum" ]; then
+      echo "Error: Could not extract checksum from remote file content at ${url}.sha256. Skipping verification." >&2
+    elif [ "$local_checksum" != "$expected_checksum" ]; then
+      echo "Error: Checksum validation failed." >&2
+      echo "Expected: ${expected_checksum}" >&2
+      echo "Got:      ${local_checksum}" >&2
+      rm "${filename}"
+      exit 1
+    else
+      echo "Checksum valid."
+    fi
+fi
+
+# Ensure the binary is executable
+chmod +x "${filename}"
+
+# Verify execution (optional, assumes --version flag)
+echo "Verifying installation..."
+if ! ./"${filename}" --version > /dev/null 2>&1; then
+    echo "Warning: Could not verify ${filename} execution. It might be corrupted or lack a '--version' flag." >&2
+    echo "You may need to manually check the binary." >&2
+else
+    echo "Verification successful."
+fi
+
+echo ""
+echo "${BINARY_NAME} version ${VERSION} was successfully downloaded to the current directory as '${filename}' 🎉"
+echo ""
+echo "You can run it directly using:"
+echo "  ./${filename} [command]"
+echo ""
+
+exit 0
+
+# This part should not be reached if successful
+echo "Error: Could not find or download a suitable version of ${BINARY_NAME}." >&2
+exit 1


### PR DESCRIPTION
- Updated release workflow to upload to GCS with versioned libraries.
- Added a release file + install script on publishing for ease-of-downloads (so users don't _need_ to navigate the bucket).
    - We're not adding to PATH or anything special, because (at least from my perspective) this isn't a long-term tool (like the unified `gloo`). If a user uses this, it will likely be a one-time (or super limited-time) use.

---

Relevant Issue: https://github.com/solo-io/istio-usage-collector/issues/3