### PR TITLE
Harden Istio injection check

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -37,7 +37,7 @@ jobs:
   e2e-tests:
     name: Run E2E Tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 10 # As of 04-11-2025, tests usually complete around 2 minute, so 10 minutes is a safe timeout.
+    timeout-minutes: 10 # As of 04-30-2025, tests usually complete in around 3 minutes, so 10 minutes is a safe timeout.
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,9 @@ run-unit-tests:
 run-e2e-tests:
 	@gotestsum --junitfile junit-e2e-test.xml -- -tags=e2e ./...
 
+run-performance-tests:
+	@gotestsum --junitfile junit-performance-test.xml -- -tags=performance ./...
+
 add-test-dependencies:
 	@helm repo add metrics-server "https://kubernetes-sigs.github.io/metrics-server/"
 	@helm repo add istio "https://istio-release.storage.googleapis.com/charts"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The Istio Usage Collector is a Go implementation of the [`gather-cluster-info.sh
 
 This data is collected into a JSON or YAML file that can be used for further analysis through our detailed migration estimator tool.
 
+Istio data gathered and reported is based on automatic sidecar injection defined within Istio's MutatingAdmissionWebhooks.
+
 ## Installation
 
 ### Downloading release

--- a/changelogs/v0.1.5.yaml
+++ b/changelogs/v0.1.5.yaml
@@ -1,2 +1,2 @@
 enhancement:
-- Check for pod-level istio injection
+- Use Istio's MutatingAdmissionWebhooks to check for (automatic) istio injection instead of manual label checks. This is to simulate Istio's `istioctl x check-inject` command.

--- a/changelogs/v0.1.5.yaml
+++ b/changelogs/v0.1.5.yaml
@@ -1,3 +1,6 @@
+new-feature:
+- Add a `max-processors` flag to the command to limit the number of processors used.
+
 enhancement:
 - Use Istio's MutatingAdmissionWebhooks to check for automatic istio injection instead of manual label checks. This is to simulate Istio's `istioctl x check-inject` command.
 

--- a/changelogs/v0.1.5.yaml
+++ b/changelogs/v0.1.5.yaml
@@ -1,0 +1,2 @@
+enhancement:
+- Check for pod-level istio injection

--- a/changelogs/v0.1.5.yaml
+++ b/changelogs/v0.1.5.yaml
@@ -1,2 +1,5 @@
 enhancement:
-- Use Istio's MutatingAdmissionWebhooks to check for (automatic) istio injection instead of manual label checks. This is to simulate Istio's `istioctl x check-inject` command.
+- Use Istio's MutatingAdmissionWebhooks to check for automatic istio injection instead of manual label checks. This is to simulate Istio's `istioctl x check-inject` command.
+
+other:
+- Add performance tests for the namespace processor.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ type CommandFlags struct {
 	OutputFilePrefix   string
 	EnableDebug        bool
 	NoProgress         bool
+	MaxProcessors      int
 }
 
 // DefaultFlags returns a CommandFlags struct initialized with default values
@@ -37,6 +38,7 @@ func DefaultFlags() *CommandFlags {
 		OutputFilePrefix:   "",
 		EnableDebug:        false,
 		NoProgress:         false,
+		MaxProcessors:      0,
 	}
 }
 
@@ -135,6 +137,7 @@ func GetCommand(customFlags ...*CommandFlags) *cobra.Command {
 				OutputFormat:       flags.OutputFormat,
 				OutputFilePrefix:   prefix,
 				NoProgress:         flags.NoProgress,
+				MaxProcessors:      flags.MaxProcessors,
 			}
 
 			// Gather cluster information
@@ -157,6 +160,7 @@ func GetCommand(customFlags ...*CommandFlags) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&flags.OutputFilePrefix, "output-prefix", "p", "", "Custom prefix for the output file. If not set, uses the cluster name.")
 	cmd.PersistentFlags().BoolVar(&flags.EnableDebug, "debug", false, "Enable debug mode.")
 	cmd.PersistentFlags().BoolVar(&flags.NoProgress, "no-progress", false, "Disable the progress bar while processing resources.")
+	cmd.PersistentFlags().IntVar(&flags.MaxProcessors, "max-processors", 0, "Maximum number of processors to use. If not set, or <= 0, it will use all available processors.")
 
 	return cmd
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -19,6 +19,7 @@ func TestRootCommandFlags(t *testing.T) {
 	assert.NotNil(t, cmd.Flag("output-prefix"))
 	assert.NotNil(t, cmd.Flag("debug"))
 	assert.NotNil(t, cmd.Flag("no-progress"))
+	assert.NotNil(t, cmd.Flag("max-processors"))
 
 	assert.Nil(t, cmd.Flag("version")) // This is only set for builds in standalone mode, not part of the command in general
 }
@@ -45,6 +46,7 @@ func TestRootCommandFlagParsing(t *testing.T) {
 				OutputFilePrefix:   "", // Default is empty string, where during execution, the context name is used
 				EnableDebug:        false,
 				NoProgress:         false,
+				MaxProcessors:      0,
 			},
 		},
 		{
@@ -58,6 +60,7 @@ func TestRootCommandFlagParsing(t *testing.T) {
 				"--output-prefix", "my-prefix",
 				"--debug",
 				"--no-progress",
+				"--max-processors", "1",
 			},
 			expectedFlags: CommandFlags{
 				HideNames:          true,
@@ -68,6 +71,7 @@ func TestRootCommandFlagParsing(t *testing.T) {
 				OutputFilePrefix:   "my-prefix",
 				EnableDebug:        true,
 				NoProgress:         true,
+				MaxProcessors:      1,
 			},
 		},
 		{
@@ -89,6 +93,7 @@ func TestRootCommandFlagParsing(t *testing.T) {
 				OutputFilePrefix:   "short-p",
 				EnableDebug:        false, // default
 				NoProgress:         false, // default
+				MaxProcessors:      0,     // default
 			},
 		},
 	}
@@ -134,6 +139,10 @@ func TestRootCommandFlagParsing(t *testing.T) {
 			noProgress, err := cmdFlags.GetBool("no-progress")
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedFlags.NoProgress, noProgress, "Flag NoProgress mismatch")
+
+			maxProcessors, err := cmdFlags.GetInt("max-processors")
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedFlags.MaxProcessors, maxProcessors, "Flag MaxProcessors mismatch")
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	k8s.io/apimachinery v0.32.3
 	k8s.io/client-go v0.32.3
 	k8s.io/metrics v0.32.3
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -61,5 +62,4 @@ require (
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/solo-io/istio-usage-collector
 go 1.23.5
 
 require (
+	github.com/google/go-cmp v0.6.0
 	github.com/pterm/pterm v0.12.80
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
@@ -28,7 +29,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gookit/color v1.5.4 // indirect

--- a/internal/gatherer/gatherer.go
+++ b/internal/gatherer/gatherer.go
@@ -493,8 +493,8 @@ func processNamespace(ctx context.Context, clientset kubernetes.Interface, metri
 
 		// Check each container
 		for _, container := range pod.Spec.Containers {
-			// TODO: What is the way to handle this?
-			isIstioProxy := container.Name == "istio-proxy"
+			// we only count istio-proxy container as an istio sidecar if the pod has istio injection enabled
+			isIstioProxy := container.Name == "istio-proxy" && isPodIstioInjected
 
 			// Count container types
 			if isIstioProxy {

--- a/internal/gatherer/gatherer.go
+++ b/internal/gatherer/gatherer.go
@@ -494,7 +494,12 @@ func processNamespace(ctx context.Context, clientset kubernetes.Interface, metri
 		// Check each container
 		for _, container := range pod.Spec.Containers {
 			// we only count istio-proxy container as an istio sidecar if the pod has istio injection enabled
-			isIstioProxy := container.Name == "istio-proxy" && isPodIstioInjected
+			isIstioProxyContainer := container.Name == "istio-proxy"
+			isIstioProxy := isIstioProxyContainer && isPodIstioInjected
+			if isIstioProxyContainer && !isPodIstioInjected {
+				// add a debug log if the pod has an istio-proxy container but istio injection is disabled, meaning we won't treat it as an istio sidecar
+				logging.Debug("%s.%s does not have istio injection enabled, treating its 'istio-proxy' container as a regular container", namespace, pod.Name)
+			}
 
 			// Count container types
 			if isIstioProxy {

--- a/internal/gatherer/gatherer.go
+++ b/internal/gatherer/gatherer.go
@@ -500,7 +500,7 @@ func processNamespace(ctx context.Context, clientset kubernetes.Interface, metri
 		// Check if istio injection is enabled on the pod-level
 		isPodIstioInjected := utils.CheckInject(istioWebhooks, pod.Labels, ns.Labels)
 
-		// if the namespace has istio injection enabled, or if the pod has istio injection enabled, we should count it as istio injected
+		// If any pod within the namespace has istio injection occurring, we should count the namespace as having istio injected
 		isIstioInjected = isIstioInjected || isPodIstioInjected
 
 		// Check each container

--- a/internal/gatherer/gatherer.go
+++ b/internal/gatherer/gatherer.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+
 	"github.com/solo-io/istio-usage-collector/internal/logging"
 	"github.com/solo-io/istio-usage-collector/internal/utils"
 	"github.com/solo-io/istio-usage-collector/pkg/models"
@@ -329,6 +331,12 @@ func processNamespaces(ctx context.Context, clientset kubernetes.Interface, metr
 	concurrentLimit := runtime.NumCPU() * 4
 	semaphore := make(chan struct{}, concurrentLimit)
 
+	// TODO: Get global istio injection policy for namespaces
+	webhooks, err := clientset.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		logging.Warn("Failed to list mutating webhook configurations: %v", err)
+	}
+
 	logging.Debug("Processing namespaces with up to %d concurrent requests", concurrentLimit)
 	for _, ns := range namespaces.Items {
 		// Check parent context for cancellation before spawning more goroutines
@@ -367,7 +375,7 @@ func processNamespaces(ctx context.Context, clientset kubernetes.Interface, metr
 				return
 			}
 
-			nsInfo, err := processNamespace(workerCtx, clientset, metricsClient, namespace.Name, hasMetrics)
+			nsInfo, err := processNamespace(workerCtx, clientset, metricsClient, namespace.Name, hasMetrics, webhooks)
 
 			if progress != nil {
 				progress.Increment()
@@ -411,37 +419,22 @@ func processNamespaces(ctx context.Context, clientset kubernetes.Interface, metr
 }
 
 // processNamespace processes an individual namespace
-// TODO: We currently don't check for the global istio injection policy to fall back to if no labels are set (.sidecarInjectorWebhook.enableNamespacesByDefault=true).
-// - NOTE: there is an _experimental_ istioctl feature (istioctl x check-inject) which could be utilized here instead of manually checking labels, but (1) it's experimental and (2) its output isn't easily parseable.
 // TODO: We currently don't check for Sidecar CRs -- https://istio.io/latest/docs/reference/config/networking/sidecar/
-func processNamespace(ctx context.Context, clientset kubernetes.Interface, metricsClient metricsv.Interface, namespace string, hasMetrics bool) (*models.NamespaceInfo, error) {
+func processNamespace(ctx context.Context, clientset kubernetes.Interface, metricsClient metricsv.Interface, namespace string, hasMetrics bool, webhooks *admissionregistrationv1.MutatingWebhookConfigurationList) (*models.NamespaceInfo, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
+
+	webhooksList := make([]admissionregistrationv1.MutatingWebhookConfiguration, 0)
+	if webhooks != nil {
+		webhooksList = webhooks.Items
+	}
+	istioWebhooks := utils.FilterIstioWebhooks(webhooksList)
 
 	// Check if namespace has Istio injection
 	ns, err := clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get namespace details: %w", err)
-	}
-
-	// istio injection on a namespace-level is based on the namespace labels (istio-injection or istio.io/rev)
-	// if istio-injection is explicitly disabled, we should return false for the namespace-level istio injection status
-	var isNamespaceIstioInjected *bool
-	if value, ok := ns.Labels["istio-injection"]; ok {
-		if value == "enabled" {
-			isNamespaceIstioInjected = &[]bool{true}[0]
-		} else if value == "disabled" {
-			isNamespaceIstioInjected = &[]bool{false}[0]
-		}
-	} else if _, ok := ns.Labels["istio.io/rev"]; ok {
-		isNamespaceIstioInjected = &[]bool{true}[0]
-	}
-
-	if isNamespaceIstioInjected != nil && *isNamespaceIstioInjected {
-		logging.Debug("Namespace %s has Istio injection enabled", namespace)
-	} else {
-		logging.Debug("Namespace %s has no Istio injection", namespace)
 	}
 
 	// Get pods in the namespace
@@ -487,32 +480,20 @@ func processNamespace(ctx context.Context, clientset kubernetes.Interface, metri
 	istioCpuActual := 0.0
 	istioMemActual := 0.0
 
-	// use this to determine if the namespace has any pods with istio injection enabled
-	doesNamespaceHaveIstioInjectedPods := false
+	// Whether the namespace has at least one pod with istio injection
+	isIstioInjected := false
 
 	// Process all pods
 	for _, pod := range pods.Items {
 		// Check if istio injection is enabled on the pod-level
-		var isPodIstioInjected *bool
+		isPodIstioInjected := utils.CheckInject(istioWebhooks, pod.Labels, ns.Labels)
 
-		if value, ok := pod.Labels["sidecar.istio.io/inject"]; ok {
-			if value == "true" {
-				isPodIstioInjected = &[]bool{true}[0]
-			} else if value == "false" {
-				isPodIstioInjected = &[]bool{false}[0]
-			}
-		} else if _, ok := pod.Labels["istio.io/rev"]; ok {
-			isPodIstioInjected = &[]bool{true}[0]
-		}
-
-		// use this to toggle the overall namespace-level istio injection status
-		if isPodIstioInjected != nil && *isPodIstioInjected {
-			doesNamespaceHaveIstioInjectedPods = true
-		}
+		// if the namespace has istio injection enabled, or if the pod has istio injection enabled, we should count it as istio injected
+		isIstioInjected = isIstioInjected || isPodIstioInjected
 
 		// Check each container
 		for _, container := range pod.Spec.Containers {
-			// TODO/Q: Should we count it as an istio proxy if the pod (or namespace) has istio injection enabled? Or solely based on the istio-proxy container name, as we do now?
+			// TODO: What is the way to handle this?
 			isIstioProxy := container.Name == "istio-proxy"
 
 			// Count container types
@@ -570,22 +551,10 @@ func processNamespace(ctx context.Context, clientset kubernetes.Interface, metri
 		}
 	}
 
-	// TODO: this should be replaced with the global istio injection policy for namespaces
-	fallbackIstioInjectionEnabled := false
-	isIstioExplicitlyDisabled := isNamespaceIstioInjected != nil && !*isNamespaceIstioInjected
-	// if the label for namesoace injection was not set, we should use the fallback istio injection policy for namespaces
-	if isNamespaceIstioInjected == nil {
-		isNamespaceIstioInjected = &fallbackIstioInjectionEnabled
-	}
-
-	// Determine if the namespace has istio injection (whether on the namespace-level [utilizing the fallback policy] or within any of its pods)
-	isIstioInjected := !isIstioExplicitlyDisabled && (*isNamespaceIstioInjected || doesNamespaceHaveIstioInjectedPods)
-
 	// Create namespace info (before appending actual resource usage and istio resources)
 	nsInfo := &models.NamespaceInfo{
 		Pods: len(pods.Items),
 		// the namespace had istio injected if it was either enabled on the namespace-level OR within any of its pods
-		// in the case of the namespace having istio injection explicitly disabled, regardless of whether any of its pods have istio injection enabled, we should return false because
 		IsIstioInjected: isIstioInjected,
 		Resources: models.ResourceInfo{
 			Regular: models.ContainerResources{

--- a/internal/gatherer/gatherer.go
+++ b/internal/gatherer/gatherer.go
@@ -11,8 +11,6 @@ import (
 	"sync"
 	"time"
 
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-
 	"github.com/solo-io/istio-usage-collector/internal/logging"
 	"github.com/solo-io/istio-usage-collector/internal/utils"
 	"github.com/solo-io/istio-usage-collector/pkg/models"
@@ -331,12 +329,6 @@ func processNamespaces(ctx context.Context, clientset kubernetes.Interface, metr
 	concurrentLimit := runtime.NumCPU() * 4
 	semaphore := make(chan struct{}, concurrentLimit)
 
-	// TODO: Get global istio injection policy for namespaces
-	webhooks, err := clientset.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		logging.Warn("Failed to list mutating webhook configurations: %v", err)
-	}
-
 	logging.Debug("Processing namespaces with up to %d concurrent requests", concurrentLimit)
 	for _, ns := range namespaces.Items {
 		// Check parent context for cancellation before spawning more goroutines
@@ -375,7 +367,7 @@ func processNamespaces(ctx context.Context, clientset kubernetes.Interface, metr
 				return
 			}
 
-			nsInfo, err := processNamespace(workerCtx, clientset, metricsClient, namespace.Name, hasMetrics, webhooks)
+			nsInfo, err := processNamespace(workerCtx, clientset, metricsClient, namespace.Name, hasMetrics)
 
 			if progress != nil {
 				progress.Increment()
@@ -419,22 +411,28 @@ func processNamespaces(ctx context.Context, clientset kubernetes.Interface, metr
 }
 
 // processNamespace processes an individual namespace
-// TODO: We currently don't check for Sidecar CRs -- https://istio.io/latest/docs/reference/config/networking/sidecar/
-func processNamespace(ctx context.Context, clientset kubernetes.Interface, metricsClient metricsv.Interface, namespace string, hasMetrics bool, webhooks *admissionregistrationv1.MutatingWebhookConfigurationList) (*models.NamespaceInfo, error) {
+func processNamespace(ctx context.Context, clientset kubernetes.Interface, metricsClient metricsv.Interface, namespace string, hasMetrics bool) (*models.NamespaceInfo, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
-
-	webhooksList := make([]admissionregistrationv1.MutatingWebhookConfiguration, 0)
-	if webhooks != nil {
-		webhooksList = webhooks.Items
-	}
-	istioWebhooks := utils.FilterIstioWebhooks(webhooksList)
 
 	// Check if namespace has Istio injection
 	ns, err := clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get namespace details: %w", err)
+	}
+
+	isIstioInjected := false
+	if value, ok := ns.Labels["istio-injection"]; ok && value == "enabled" {
+		isIstioInjected = true
+	} else if _, ok := ns.Labels["istio.io/rev"]; ok {
+		isIstioInjected = true
+	}
+
+	if isIstioInjected {
+		logging.Debug("Namespace %s has Istio injection enabled", namespace)
+	} else {
+		logging.Debug("Namespace %s has no Istio injection", namespace)
 	}
 
 	// Get pods in the namespace
@@ -480,26 +478,11 @@ func processNamespace(ctx context.Context, clientset kubernetes.Interface, metri
 	istioCpuActual := 0.0
 	istioMemActual := 0.0
 
-	// Whether the namespace has at least one pod with istio injection
-	isIstioInjected := false
-
 	// Process all pods
 	for _, pod := range pods.Items {
-		// Check if istio injection is enabled on the pod-level
-		isPodIstioInjected := utils.CheckInject(istioWebhooks, pod.Labels, ns.Labels)
-
-		// if the namespace has istio injection enabled, or if the pod has istio injection enabled, we should count it as istio injected
-		isIstioInjected = isIstioInjected || isPodIstioInjected
-
 		// Check each container
 		for _, container := range pod.Spec.Containers {
-			// we only count istio-proxy container as an istio sidecar if the pod has istio injection enabled
-			isIstioProxyContainer := container.Name == "istio-proxy"
-			isIstioProxy := isIstioProxyContainer && isPodIstioInjected
-			if isIstioProxyContainer && !isPodIstioInjected {
-				// add a debug log if the pod has an istio-proxy container but istio injection is disabled, meaning we won't treat it as an istio sidecar
-				logging.Debug("%s.%s does not have istio injection enabled, treating its 'istio-proxy' container as a regular container", namespace, pod.Name)
-			}
+			isIstioProxy := container.Name == "istio-proxy"
 
 			// Count container types
 			if isIstioProxy {
@@ -556,10 +539,9 @@ func processNamespace(ctx context.Context, clientset kubernetes.Interface, metri
 		}
 	}
 
-	// Create namespace info (before appending actual resource usage and istio resources)
+	// Create namespace info
 	nsInfo := &models.NamespaceInfo{
-		Pods: len(pods.Items),
-		// the namespace had istio injected if it was either enabled on the namespace-level OR within any of its pods
+		Pods:            len(pods.Items),
 		IsIstioInjected: isIstioInjected,
 		Resources: models.ResourceInfo{
 			Regular: models.ContainerResources{
@@ -579,8 +561,8 @@ func processNamespace(ctx context.Context, clientset kubernetes.Interface, metri
 		}
 	}
 
-	// Add Istio resources if the namespace has Istio injection (either namespace-level or pod-level)
-	if nsInfo.IsIstioInjected {
+	// Add Istio resources if the namespace has Istio injection
+	if isIstioInjected {
 		nsInfo.Resources.Istio = &models.ContainerResources{
 			Containers: istioContainers,
 			Request: models.Resources{

--- a/internal/gatherer/gatherer.go
+++ b/internal/gatherer/gatherer.go
@@ -591,7 +591,7 @@ func processNamespace(ctx context.Context, clientset kubernetes.Interface, metri
 		}
 	}
 
-	// Add Istio resources if the namespace has Istio injection (either namespace-level or pod-level)
+	// Only add the Istio resources field if the namespace contained at least one pod with istio injection
 	if nsInfo.IsIstioInjected {
 		nsInfo.Resources.Istio = &models.ContainerResources{
 			Containers: istioContainers,

--- a/internal/gatherer/gatherer_performance_test.go
+++ b/internal/gatherer/gatherer_performance_test.go
@@ -1,4 +1,4 @@
-//go:build performance
+////go:build performance
 
 package gatherer
 
@@ -221,6 +221,7 @@ type benchmarkCase struct {
 	configPath          string
 	revisionWebhookPath string
 	sidecarWebhookPath  string
+	maxProcessors       int
 }
 
 type benchmarkResult struct {
@@ -235,16 +236,32 @@ func BenchmarkProcessNamespaces(b *testing.B) {
 	// Define benchmark cases
 	cases := []benchmarkCase{
 		{
-			name:                "Large Namespaces",
+			name:                "LargeNamespaces_MultiProcessor",
 			configPath:          "../../tests/data/performance/large_namespaces.yaml",
 			revisionWebhookPath: "../../tests/data/default-istio-revision-tag-mwh.yaml",
 			sidecarWebhookPath:  "../../tests/data/default-istio-sidecar-injector-mwh.yaml",
+			maxProcessors:       0,
 		},
 		{
-			name:                "Large Pods",
+			name:                "LargeNamespaces_SingleProcessor",
+			configPath:          "../../tests/data/performance/large_namespaces.yaml",
+			revisionWebhookPath: "../../tests/data/default-istio-revision-tag-mwh.yaml",
+			sidecarWebhookPath:  "../../tests/data/default-istio-sidecar-injector-mwh.yaml",
+			maxProcessors:       1,
+		},
+		{
+			name:                "LargePods_MultiProcessor",
 			configPath:          "../../tests/data/performance/large_pods.yaml",
 			revisionWebhookPath: "../../tests/data/default-istio-revision-tag-mwh.yaml",
 			sidecarWebhookPath:  "../../tests/data/default-istio-sidecar-injector-mwh.yaml",
+			maxProcessors:       0,
+		},
+		{
+			name:                "LargePods_SingleProcessor",
+			configPath:          "../../tests/data/performance/large_pods.yaml",
+			revisionWebhookPath: "../../tests/data/default-istio-revision-tag-mwh.yaml",
+			sidecarWebhookPath:  "../../tests/data/default-istio-sidecar-injector-mwh.yaml",
+			maxProcessors:       1,
 		},
 	}
 
@@ -303,6 +320,7 @@ func BenchmarkProcessNamespaces(b *testing.B) {
 				KubeContext:    fmt.Sprintf("benchmark-context-%s", bc.name),
 				ObfuscateNames: false,
 				NoProgress:     true, // Disable progress bar during benchmark for cleaner console output
+				MaxProcessors:  bc.maxProcessors,
 			}
 
 			// Check if any namespace config requires metrics

--- a/internal/gatherer/gatherer_performance_test.go
+++ b/internal/gatherer/gatherer_performance_test.go
@@ -1,0 +1,387 @@
+////go:build test || performance
+
+package gatherer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/solo-io/istio-usage-collector/internal/utils"
+	"github.com/solo-io/istio-usage-collector/pkg/models"
+	"sigs.k8s.io/yaml"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+	v1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
+	metricsfake "k8s.io/metrics/pkg/client/clientset/versioned/fake"
+)
+
+// --- Structs for Declarative Test Configuration ---
+
+// PerformanceTestConfig defines the overall structure for the performance test YAML config.
+type PerformanceTestConfig struct {
+	Namespaces []NamespaceConfig `yaml:"namespaces"`
+	// Add Node configuration later if needed
+}
+
+// NamespaceConfig defines the configuration for a single namespace in the test.
+type NamespaceConfig struct {
+	NamePrefix      string            `yaml:"namePrefix"`      // Prefix for generated namespace names
+	Count           int               `yaml:"count"`           // Number of namespaces to generate with this config
+	Labels          map[string]string `yaml:"labels"`          // Labels to apply to the namespace
+	PodConfig       PodConfig         `yaml:"podConfig"`       // Configuration for pods within this namespace
+	HasMetrics      bool              `yaml:"hasMetrics"`      // Whether to generate metrics for pods in this namespace
+	IsIstioInjected bool              `yaml:"isIstioInjected"` // Convenience flag to set injection labels automatically
+}
+
+// PodConfig defines the configuration for pods within a namespace.
+type PodConfig struct {
+	NamePrefix        string            `yaml:"namePrefix"`        // Prefix for generated pod names
+	Count             int               `yaml:"count"`             // Number of pods to generate per namespace
+	Labels            map[string]string `yaml:"labels"`            // Labels to apply to the pod
+	NodeNamePrefix    string            `yaml:"nodeNamePrefix"`    // Prefix for node names pods are scheduled on
+	AppContainer      ContainerConfig   `yaml:"appContainer"`      // Configuration for the main application container
+	IstioProxy        *ContainerConfig  `yaml:"istioProxy"`        // Configuration for the istio-proxy container (optional)
+	HasIstioProxy     bool              `yaml:"hasIstioProxy"`     // Explicitly state if istio-proxy container should exist (used even if NamespaceConfig.IsIstioInjected is false for testing edge cases)
+	IstioInjectedBy   string            `yaml:"istioInjectedBy"`   // How istio injection is determined ("namespace", "podLabel", "revisionLabel", "" (none)) - defaults to "namespace" if NamespaceConfig.IsIstioInjected is true
+	IstioRevisionName string            `yaml:"istioRevisionName"` // Revision name used if istioInjectedBy is "revisionLabel"
+}
+
+// ContainerConfig defines the resource requests and usage for a container.
+type ContainerConfig struct {
+	CPURequest string `yaml:"cpuRequest"` // e.g., "100m"
+	MemRequest string `yaml:"memRequest"` // e.g., "128Mi"
+	CPUActual  string `yaml:"cpuActual"`  // e.g., "50m" - Only used if NamespaceConfig.HasMetrics is true
+	MemActual  string `yaml:"memActual"`  // e.g., "64Mi" - Only used if NamespaceConfig.HasMetrics is true
+}
+
+// --- End Structs ---
+
+// --- Helper Functions for Declarative Test Setup ---
+
+// loadPerformanceTestConfig loads the test configuration from the specified YAML file.
+func loadPerformanceTestConfig(filePath string) (*PerformanceTestConfig, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read performance test config file %s: %w", filePath, err)
+	}
+
+	var config PerformanceTestConfig
+	err = yaml.Unmarshal(data, &config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal performance test config from %s: %w", filePath, err)
+	}
+
+	return &config, nil
+}
+
+// generateMockResources creates fake Kubernetes and metrics objects based on the config.
+func generateMockResources(config *PerformanceTestConfig) ([]runtime.Object, []runtime.Object, error) {
+	kubeObjects := []runtime.Object{}
+	metricsObjects := []runtime.Object{}
+
+	// load default webhooks for injection checks
+	var istioRevisionTagDefaultWebhook admissionregistrationv1.MutatingWebhookConfiguration
+	data, err := os.ReadFile("../../tests/data/default-istio-revision-tag-mwh.yaml")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read default webhook file: %w", err)
+	}
+	err = yaml.Unmarshal(data, &istioRevisionTagDefaultWebhook)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal default webhook: %w", err)
+	}
+
+	var istioSidecarInjectorWebhook admissionregistrationv1.MutatingWebhookConfiguration
+	data, err = os.ReadFile("../../tests/data/default-istio-sidecar-injector-mwh.yaml")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read default webhook file: %w", err)
+	}
+	err = yaml.Unmarshal(data, &istioSidecarInjectorWebhook)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal default webhook: %w", err)
+	}
+
+	// Add webhooks to kubeObjects so they can be retrieved by processNamespace
+	kubeObjects = append(kubeObjects, &istioRevisionTagDefaultWebhook, &istioSidecarInjectorWebhook)
+
+	for _, nsConfig := range config.Namespaces {
+		for i := 0; i < nsConfig.Count; i++ {
+			nsName := fmt.Sprintf("%s%d", nsConfig.NamePrefix, i)
+			nsLabels := make(map[string]string)
+			for k, v := range nsConfig.Labels {
+				nsLabels[k] = v
+			}
+
+			// Automatically set istio-injection label if IsIstioInjected is true and not explicitly set
+			if nsConfig.IsIstioInjected {
+				if _, exists := nsLabels["istio-injection"]; !exists {
+					// only add if istio.io/rev is not set
+					if _, revExists := nsLabels["istio.io/rev"]; !revExists {
+						nsLabels["istio-injection"] = "enabled"
+					}
+				}
+			}
+
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   nsName,
+					Labels: nsLabels,
+				},
+			}
+			kubeObjects = append(kubeObjects, ns)
+
+			// Generate Pods for this namespace
+			for j := 0; j < nsConfig.PodConfig.Count; j++ {
+				podName := fmt.Sprintf("%s%d", nsConfig.PodConfig.NamePrefix, j)
+				nodeName := fmt.Sprintf("%s%d", nsConfig.PodConfig.NodeNamePrefix, j%5) // Distribute pods across a few nodes
+				podLabels := make(map[string]string)
+				for k, v := range nsConfig.PodConfig.Labels {
+					podLabels[k] = v
+				}
+
+				// Determine istio injection based on config
+				hasIstioSidecar := nsConfig.PodConfig.HasIstioProxy
+				isPodIstioInjected := false
+				injectionMechanism := nsConfig.PodConfig.IstioInjectedBy
+				if nsConfig.IsIstioInjected && injectionMechanism == "" {
+					injectionMechanism = "namespace" // Default to namespace if namespace is flagged and mechanism isn't specified
+				}
+
+				switch injectionMechanism {
+				case "namespace":
+					isPodIstioInjected = nsConfig.IsIstioInjected // Inherit from namespace setting
+				case "podLabel":
+					// Check namespace labels first for disable
+					if nsLabels["istio-injection"] != "disabled" {
+						podLabels["sidecar.istio.io/inject"] = "true"
+						isPodIstioInjected = true
+					}
+				case "revisionLabel":
+					// Check namespace labels first for disable
+					if nsLabels["istio-injection"] != "disabled" {
+						revName := nsConfig.PodConfig.IstioRevisionName
+						if revName == "" {
+							revName = "default" // Assume default revision if not specified
+						}
+						podLabels["istio.io/rev"] = revName
+						isPodIstioInjected = true
+					}
+				default: // No injection explicitly configured for the pod
+					isPodIstioInjected = nsConfig.IsIstioInjected && nsLabels["istio-injection"] != "disabled"
+				}
+
+				// Override hasIstioSidecar based on final injection decision
+				hasIstioSidecar = hasIstioSidecar && isPodIstioInjected
+
+				// Create Pod
+				istioCPUReq := ""
+				istioMemReq := ""
+				if nsConfig.PodConfig.IstioProxy != nil {
+					istioCPUReq = nsConfig.PodConfig.IstioProxy.CPURequest
+					istioMemReq = nsConfig.PodConfig.IstioProxy.MemRequest
+				}
+
+				pod := newPod(nsName, podName, nodeName,
+					nsConfig.PodConfig.AppContainer.CPURequest,
+					nsConfig.PodConfig.AppContainer.MemRequest,
+					hasIstioSidecar, // Only add istio-proxy container if explicitly requested *and* injection is active
+					istioCPUReq,
+					istioMemReq,
+					podLabels,
+				)
+				kubeObjects = append(kubeObjects, pod)
+
+				// Generate Pod Metrics if enabled for the namespace
+				if nsConfig.HasMetrics {
+					istioCPUAct := ""
+					istioMemAct := ""
+					if hasIstioSidecar && nsConfig.PodConfig.IstioProxy != nil {
+						istioCPUAct = nsConfig.PodConfig.IstioProxy.CPUActual
+						istioMemAct = nsConfig.PodConfig.IstioProxy.MemActual
+					}
+					podMetrics := newPodMetrics(nsName, podName,
+						nsConfig.PodConfig.AppContainer.CPUActual,
+						nsConfig.PodConfig.AppContainer.MemActual,
+						hasIstioSidecar,
+						istioCPUAct,
+						istioMemAct,
+					)
+					metricsObjects = append(metricsObjects, podMetrics)
+				}
+			}
+		}
+	}
+
+	return kubeObjects, metricsObjects, nil
+}
+
+// --- End Helper Functions ---
+
+// Helper function to create a simple pod
+func newPod(namespace, name, nodeName string, cpuRequest, memRequest string, hasIstioProxy bool, istioProxyCpu, istioProxyMem string, labels map[string]string) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+			Containers: []corev1.Container{
+				{
+					Name: "app",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{},
+					},
+				},
+			},
+		},
+	}
+	if cpuRequest != "" {
+		pod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse(cpuRequest)
+	}
+	if memRequest != "" {
+		pod.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory] = resource.MustParse(memRequest)
+	}
+
+	if hasIstioProxy {
+		istioContainer := corev1.Container{
+			Name: "istio-proxy",
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse(istioProxyCpu),
+					corev1.ResourceMemory: resource.MustParse(istioProxyMem),
+				},
+			},
+		}
+		pod.Spec.Containers = append(pod.Spec.Containers, istioContainer)
+	}
+	return pod
+}
+
+// Helper function to create pod metrics
+func newPodMetrics(namespace, name string, cpuUsage, memUsage string, hasIstioProxy bool, istioCpuUsage, istioMemUsage string) *v1beta1.PodMetrics {
+	metrics := &v1beta1.PodMetrics{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Containers: []v1beta1.ContainerMetrics{
+			{
+				Name: "app",
+				Usage: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse(cpuUsage),
+					corev1.ResourceMemory: resource.MustParse(memUsage),
+				},
+			},
+		},
+	}
+	if hasIstioProxy {
+		istioMetrics := v1beta1.ContainerMetrics{
+			Name: "istio-proxy",
+			Usage: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(istioCpuUsage),
+				corev1.ResourceMemory: resource.MustParse(istioMemUsage),
+			},
+		}
+		metrics.Containers = append(metrics.Containers, istioMetrics)
+	}
+	return metrics
+}
+
+func BenchmarkProcessNamespaces(b *testing.B) {
+	configPath := "../../tests/data/gatherer_namespace_performance_test_config.yaml"
+	config, err := loadPerformanceTestConfig(configPath)
+	if err != nil {
+		b.Fatalf("Failed to load performance test config: %v", err)
+	}
+
+	kubeObjects, metricsObjects, err := generateMockResources(config)
+	if err != nil {
+		b.Fatalf("Failed to generate mock resources: %v", err)
+	}
+	b.Logf("Generated %d kube objects and %d metrics objects\n", len(kubeObjects), len(metricsObjects))
+
+	// Prepare fake clients
+	fakeClient := fake.NewSimpleClientset(kubeObjects...)
+	fakeMetricsClient := metricsfake.NewSimpleClientset(metricsObjects...)
+
+	// Set up metrics client reactors (handle potential nil metrics list for specific namespaces)
+	fakeMetricsClient.PrependReactor("list", "pods", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		listAction := action.(clienttesting.ListAction)
+		ns := listAction.GetNamespace()
+
+		// Filter metricsObjects for the requested namespace
+		nsMetrics := &v1beta1.PodMetricsList{Items: []v1beta1.PodMetrics{}}
+		for _, obj := range metricsObjects {
+			if podMetrics, ok := obj.(*v1beta1.PodMetrics); ok {
+				if podMetrics.Namespace == ns {
+					nsMetrics.Items = append(nsMetrics.Items, *podMetrics)
+				}
+			}
+		}
+		return true, nsMetrics, nil
+	})
+
+	// Prepare ClusterInfo and Config for processNamespaces
+	clusterInfo := models.NewClusterInfo() // Start with an empty ClusterInfo for each run
+	// Basic config for the benchmark
+	processCfg := &utils.Config{
+		KubeContext:    "benchmark-context",
+		ObfuscateNames: false,
+		NoProgress:     false, // TODO (maybe): Disable progress bar during benchmark
+	}
+
+	// Check if any namespace config requires metrics
+	hasMetricsInConfig := false
+	for _, nsConfig := range config.Namespaces {
+		if nsConfig.HasMetrics {
+			hasMetricsInConfig = true
+			break
+		}
+	}
+
+	b.ResetTimer() // Start timing after setup
+
+	for i := 0; i < b.N; i++ {
+		// It's important to create a new context for each iteration
+		// to avoid potential issues with context cancellation across iterations.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute) // Generous timeout for processing
+
+		// Reset clusterInfo partially if needed, or create anew if easier
+		// For this benchmark, let's process into the same map repeatedly.
+		// If state carryover is an issue, create a new clusterInfo inside the loop.
+		// clusterInfo := models.NewClusterInfo()
+
+		err := processNamespaces(ctx, fakeClient, fakeMetricsClient, clusterInfo, processCfg, hasMetricsInConfig)
+
+		cancel() // Cancel context at the end of each iteration
+
+		if err != nil {
+			// Stop the benchmark if an error occurs during processing
+			b.Fatalf("Benchmark iteration %d failed: %v", i, err)
+		}
+	}
+
+	b.StopTimer() // Stop timing explicitly (though ResetTimer implicitly does this at start)
+
+	// Calculate totals for logging
+	totalNamespaces := 0
+	totalPods := 0
+	for _, nsConfig := range config.Namespaces {
+		totalNamespaces += nsConfig.Count
+		totalPods += nsConfig.Count * nsConfig.PodConfig.Count
+	}
+	b.ReportMetric(float64(len(clusterInfo.Namespaces)), "namespaces_processed")
+	b.ReportMetric(float64(totalPods), "pods_processed")
+}
+
+// --- End Benchmark Function ---

--- a/internal/gatherer/gatherer_performance_test.go
+++ b/internal/gatherer/gatherer_performance_test.go
@@ -1,4 +1,4 @@
-////go:build performance
+//go:build performance
 
 package gatherer
 

--- a/internal/gatherer/gatherer_test.go
+++ b/internal/gatherer/gatherer_test.go
@@ -41,7 +41,7 @@ func TestProcessNamespace(t *testing.T) {
 	err = yaml.Unmarshal(data, &istioSidecarInjectorWebhook)
 	require.NoError(t, err)
 
-	defaultMutatingWebhookList := admissionregistrationv1.MutatingWebhookConfigurationList{Items: []admissionregistrationv1.MutatingWebhookConfiguration{istioRevisionTagDefaultWebhook, istioSidecarInjectorWebhook}}
+	defaultIstioMutatingWebhooks := []admissionregistrationv1.MutatingWebhookConfiguration{istioRevisionTagDefaultWebhook, istioSidecarInjectorWebhook}
 
 	tests := []struct {
 		name           string
@@ -350,7 +350,7 @@ func TestProcessNamespace(t *testing.T) {
 				return true, podMetricsList, nil
 			})
 
-			nsInfo, err := processNamespace(ctx, fakeClient, fakeMetricsClient, tt.namespace, tt.hasMetricsAPI, &defaultMutatingWebhookList)
+			nsInfo, err := processNamespace(ctx, fakeClient, fakeMetricsClient, tt.namespace, tt.hasMetricsAPI, defaultIstioMutatingWebhooks)
 
 			if tt.expectError {
 				assert.Error(t, err)

--- a/internal/utils/istio.go
+++ b/internal/utils/istio.go
@@ -1,0 +1,109 @@
+package utils
+
+// A minified version of istioctl's checkinject command which checks if a pod is automatically injected with an istio sidecar: https://github.com/istio/istio/tree/master/istioctl/pkg/checkinject
+
+import (
+	"fmt"
+	"strings"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// FilterIstioWebhooks filters out non-istio webhooks from a list of webhooks
+func FilterIstioWebhooks(whs []admissionregistrationv1.MutatingWebhookConfiguration) []admissionregistrationv1.MutatingWebhookConfiguration {
+	istioWebhooks := make([]admissionregistrationv1.MutatingWebhookConfiguration, 0)
+	for _, mwc := range whs {
+		if isIstioWebhook(&mwc) {
+			istioWebhooks = append(istioWebhooks, mwc)
+		}
+	}
+	return istioWebhooks
+}
+
+// CheckInject checks if a pod is automatically injected with an istio sidecar
+// It assumes the passed in mutating webhooks are only istio webhooks
+func CheckInject(istioWebhooks []admissionregistrationv1.MutatingWebhookConfiguration, podLabels, nsLabels map[string]string) bool {
+	for _, mwc := range istioWebhooks {
+		// if any istio webhook is found which injects the container, return true
+		if analyzeWebhooksMatchStatus(mwc.Webhooks, podLabels, nsLabels) {
+			return true
+		}
+	}
+	return false
+}
+
+func analyzeWebhooksMatchStatus(whs []admissionregistrationv1.MutatingWebhook, podLabels, nsLabels map[string]string) (injected bool) {
+	for _, wh := range whs {
+		nsMatched, nsLabel := extractMatchedSelectorInfo(wh.NamespaceSelector, nsLabels)
+		podMatched, podLabel := extractMatchedSelectorInfo(wh.ObjectSelector, podLabels)
+		if nsMatched && podMatched {
+			if nsLabel != "" && podLabel != "" {
+				return true
+			} else if nsLabel != "" {
+				return true
+			} else if podLabel != "" {
+				return true
+			}
+		} else if nsMatched {
+			for _, me := range wh.ObjectSelector.MatchExpressions {
+				switch me.Operator {
+				case metav1.LabelSelectorOpDoesNotExist:
+					if _, ok := podLabels[me.Key]; ok {
+						return false
+					}
+				case metav1.LabelSelectorOpNotIn:
+					v, ok := podLabels[me.Key]
+					if !ok {
+						continue
+					}
+					for _, nv := range me.Values {
+						if nv == v {
+							return false
+						}
+					}
+				}
+			}
+		} else if podMatched {
+			if v, ok := nsLabels["istio-injection"]; ok {
+				if v != "enabled" {
+					return false
+				}
+			}
+		}
+	}
+	return false
+}
+
+func extractMatchedSelectorInfo(ls *metav1.LabelSelector, objLabels map[string]string) (matched bool, injLabel string) {
+	if ls == nil {
+		return true, ""
+	}
+	selector, err := metav1.LabelSelectorAsSelector(ls)
+	if err != nil {
+		return false, ""
+	}
+	matched = selector.Matches(labels.Set(objLabels))
+	if !matched {
+		return matched, ""
+	}
+	for _, me := range ls.MatchExpressions {
+		switch me.Operator {
+		case metav1.LabelSelectorOpIn, metav1.LabelSelectorOpNotIn:
+			if v, exist := objLabels[me.Key]; exist {
+				return matched, fmt.Sprintf("%s=%s", me.Key, v)
+			}
+		}
+	}
+	return matched, ""
+}
+
+func isIstioWebhook(wh *admissionregistrationv1.MutatingWebhookConfiguration) bool {
+	for _, w := range wh.Webhooks {
+		if strings.HasSuffix(w.Name, "istio.io") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/utils/types.go
+++ b/internal/utils/types.go
@@ -22,4 +22,8 @@ type Config struct {
 
 	// NoProgress indicates whether to disable the progress bar
 	NoProgress bool
+
+	// MaxProcessors is the maximum number of processors to use.
+	// By default, all available processors will be used.
+	MaxProcessors int
 }

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -11,7 +11,7 @@ type ClusterInfo struct {
 // NamespaceInfo represents information about a Kubernetes namespace
 type NamespaceInfo struct {
 	Pods int `json:"pods" yaml:"pods"`
-	// IsIstioInjected is true if the namespace has istio injection enabled or if a pod within the namespace has istio injection enabled
+	// IsIstioInjected is true the namespace contains at least one pod with istio injection enabled
 	IsIstioInjected bool         `json:"is_istio_injected" yaml:"is_istio_injected"`
 	Resources       ResourceInfo `json:"resources" yaml:"resources"`
 }

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -10,7 +10,8 @@ type ClusterInfo struct {
 
 // NamespaceInfo represents information about a Kubernetes namespace
 type NamespaceInfo struct {
-	Pods            int          `json:"pods" yaml:"pods"`
+	Pods int `json:"pods" yaml:"pods"`
+	// IsIstioInjected is true if the namespace has istio injection enabled or if a pod within the namespace has istio injection enabled
 	IsIstioInjected bool         `json:"is_istio_injected" yaml:"is_istio_injected"`
 	Resources       ResourceInfo `json:"resources" yaml:"resources"`
 }

--- a/tests/data/default-istio-revision-tag-mwh.yaml
+++ b/tests/data/default-istio-revision-tag-mwh.yaml
@@ -1,0 +1,179 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    app: sidecar-injector
+    app.kubernetes.io/instance: istio
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: istiod
+    app.kubernetes.io/part-of: istio
+    app.kubernetes.io/version: 1.25.0
+    helm.sh/chart: istiod-1.25.0
+    install.operator.istio.io/owning-resource: unknown
+    install.operator.istio.io/owning-resource-namespace: istio-system
+    install.operator.istio.io/owning-resource-not-pruned: "true"
+    istio.io/rev: default
+    istio.io/tag: default
+    operator.istio.io/component: Pilot
+    operator.istio.io/managed: Reconcile
+    operator.istio.io/version: 1.25.0
+    release: istio
+  name: istio-revision-tag-default
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMvVENDQWVXZ0F3SUJBZ0lSQU9LelltVkVTZHM5ODlLd2Z3UmNYK2d3RFFZSktvWklodmNOQVFFTEJRQXcKR0RFV01CUUdBMVVFQ2hNTlkyeDFjM1JsY2k1c2IyTmhiREFlRncweU5UQTBNekF4T1RVMU5EWmFGdzB6TlRBMApNamd4T1RVMU5EWmFNQmd4RmpBVUJnTlZCQW9URFdOc2RYTjBaWEl1Ykc5allXd3dnZ0VpTUEwR0NTcUdTSWIzCkRRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRREV4UFVlcUlHeXFONGQwcVo2MGlVS1djS3dnaEpJSDJKNHp3SVcKUmxacHE0QmFhSThTOHBhTkZvbS9uRjhRaStlQzI3QTc4TXgrbzhtQ1Y3SWVRUG8vMWkxTXY4b3JmRklYQzRocApjNUNGUDNaVkdvMzM2SXVVV3c5ME1yTnNwQ04wRkJLMHhHS3U5aGlpOTloemgwR28vd0VJYlQvb1FyYURaSTdwCk1QNDduc0hFMFFiK2VIeFJrR21PUDA3dkhFWmN6bFpkcCs1RGpxS0ZQdG5mZk1DSXNSSCtKdElqS09hOGZNM1gKcnZEWXpzNnBlL3JMcnk2ZW1IVmcvU2gzeFFHaENvQm1vWW1VVUpRUkZQenNGZVRZbXBpMDd5eis5NlZpeFI0UQp3ZHdib2JwYWFjb0NHZnlqWVAySTlmWEw2WHpVMjUyVTVGOWpFR1pHQUdoSXVHdkxBZ01CQUFHalFqQkFNQTRHCkExVWREd0VCL3dRRUF3SUNCREFQQmdOVkhSTUJBZjhFQlRBREFRSC9NQjBHQTFVZERnUVdCQlMzTERtU3FmVUUKMExzTUF2UWxhd2c1OEtrRkxEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFBWldJNUJHOXNCa0JqTFIzWFlMcwpGcGJrSDlGc283MjYvY1NmN3loVGlkVk5ZVGhKTXBZdXFaM1FReHNnbWVWZm9uUzYyWDlDa2FBeHlkcmpxNDEzCmpxaWwzRmQ4ei93bXRlbFE3N01DM2pPNXl2bzhhZXlwS0ZyUnJ5T0tDbnlDUkY0STBtUUdTakQxcVMySHUxSloKRzVDeCttRHpvRVBQdVY0cGJjSzBlMnhWR2pnNktRUXFTUGtuYkJVRjczVmxqSE5YMmFEYmJITTdoendLbW5MWApPQTY4WnlZSmRyNVhhOE9NZEMxMW8vTW1pK3hlQ2xmbXRjN1RxZGhwNW1ibkpZWFJDRCtLczFVRDg3NVZrTjdrCnI0THVkSXdid1Q4NzV5ZmdwL2NGeGNIOU1HWGlPcmxtZW12bWNuM2NILzZnMjIxbGo1WUVReTgydVZWTlNHblcKNEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+      service:
+        name: istiod
+        namespace: istio-system
+        path: /inject
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: rev.namespace.sidecar-injector.istio.io
+    namespaceSelector:
+      matchExpressions:
+        - key: istio.io/rev
+          operator: In
+          values:
+            - default
+        - key: istio-injection
+          operator: DoesNotExist
+    objectSelector:
+      matchExpressions:
+        - key: sidecar.istio.io/inject
+          operator: NotIn
+          values:
+            - "false"
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+        scope: "*"
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMvVENDQWVXZ0F3SUJBZ0lSQU9LelltVkVTZHM5ODlLd2Z3UmNYK2d3RFFZSktvWklodmNOQVFFTEJRQXcKR0RFV01CUUdBMVVFQ2hNTlkyeDFjM1JsY2k1c2IyTmhiREFlRncweU5UQTBNekF4T1RVMU5EWmFGdzB6TlRBMApNamd4T1RVMU5EWmFNQmd4RmpBVUJnTlZCQW9URFdOc2RYTjBaWEl1Ykc5allXd3dnZ0VpTUEwR0NTcUdTSWIzCkRRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRREV4UFVlcUlHeXFONGQwcVo2MGlVS1djS3dnaEpJSDJKNHp3SVcKUmxacHE0QmFhSThTOHBhTkZvbS9uRjhRaStlQzI3QTc4TXgrbzhtQ1Y3SWVRUG8vMWkxTXY4b3JmRklYQzRocApjNUNGUDNaVkdvMzM2SXVVV3c5ME1yTnNwQ04wRkJLMHhHS3U5aGlpOTloemgwR28vd0VJYlQvb1FyYURaSTdwCk1QNDduc0hFMFFiK2VIeFJrR21PUDA3dkhFWmN6bFpkcCs1RGpxS0ZQdG5mZk1DSXNSSCtKdElqS09hOGZNM1gKcnZEWXpzNnBlL3JMcnk2ZW1IVmcvU2gzeFFHaENvQm1vWW1VVUpRUkZQenNGZVRZbXBpMDd5eis5NlZpeFI0UQp3ZHdib2JwYWFjb0NHZnlqWVAySTlmWEw2WHpVMjUyVTVGOWpFR1pHQUdoSXVHdkxBZ01CQUFHalFqQkFNQTRHCkExVWREd0VCL3dRRUF3SUNCREFQQmdOVkhSTUJBZjhFQlRBREFRSC9NQjBHQTFVZERnUVdCQlMzTERtU3FmVUUKMExzTUF2UWxhd2c1OEtrRkxEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFBWldJNUJHOXNCa0JqTFIzWFlMcwpGcGJrSDlGc283MjYvY1NmN3loVGlkVk5ZVGhKTXBZdXFaM1FReHNnbWVWZm9uUzYyWDlDa2FBeHlkcmpxNDEzCmpxaWwzRmQ4ei93bXRlbFE3N01DM2pPNXl2bzhhZXlwS0ZyUnJ5T0tDbnlDUkY0STBtUUdTakQxcVMySHUxSloKRzVDeCttRHpvRVBQdVY0cGJjSzBlMnhWR2pnNktRUXFTUGtuYkJVRjczVmxqSE5YMmFEYmJITTdoendLbW5MWApPQTY4WnlZSmRyNVhhOE9NZEMxMW8vTW1pK3hlQ2xmbXRjN1RxZGhwNW1ibkpZWFJDRCtLczFVRDg3NVZrTjdrCnI0THVkSXdid1Q4NzV5ZmdwL2NGeGNIOU1HWGlPcmxtZW12bWNuM2NILzZnMjIxbGo1WUVReTgydVZWTlNHblcKNEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+      service:
+        name: istiod
+        namespace: istio-system
+        path: /inject
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: rev.object.sidecar-injector.istio.io
+    namespaceSelector:
+      matchExpressions:
+        - key: istio.io/rev
+          operator: DoesNotExist
+        - key: istio-injection
+          operator: DoesNotExist
+    objectSelector:
+      matchExpressions:
+        - key: sidecar.istio.io/inject
+          operator: NotIn
+          values:
+            - "false"
+        - key: istio.io/rev
+          operator: In
+          values:
+            - default
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+        scope: "*"
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMvVENDQWVXZ0F3SUJBZ0lSQU9LelltVkVTZHM5ODlLd2Z3UmNYK2d3RFFZSktvWklodmNOQVFFTEJRQXcKR0RFV01CUUdBMVVFQ2hNTlkyeDFjM1JsY2k1c2IyTmhiREFlRncweU5UQTBNekF4T1RVMU5EWmFGdzB6TlRBMApNamd4T1RVMU5EWmFNQmd4RmpBVUJnTlZCQW9URFdOc2RYTjBaWEl1Ykc5allXd3dnZ0VpTUEwR0NTcUdTSWIzCkRRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRREV4UFVlcUlHeXFONGQwcVo2MGlVS1djS3dnaEpJSDJKNHp3SVcKUmxacHE0QmFhSThTOHBhTkZvbS9uRjhRaStlQzI3QTc4TXgrbzhtQ1Y3SWVRUG8vMWkxTXY4b3JmRklYQzRocApjNUNGUDNaVkdvMzM2SXVVV3c5ME1yTnNwQ04wRkJLMHhHS3U5aGlpOTloemgwR28vd0VJYlQvb1FyYURaSTdwCk1QNDduc0hFMFFiK2VIeFJrR21PUDA3dkhFWmN6bFpkcCs1RGpxS0ZQdG5mZk1DSXNSSCtKdElqS09hOGZNM1gKcnZEWXpzNnBlL3JMcnk2ZW1IVmcvU2gzeFFHaENvQm1vWW1VVUpRUkZQenNGZVRZbXBpMDd5eis5NlZpeFI0UQp3ZHdib2JwYWFjb0NHZnlqWVAySTlmWEw2WHpVMjUyVTVGOWpFR1pHQUdoSXVHdkxBZ01CQUFHalFqQkFNQTRHCkExVWREd0VCL3dRRUF3SUNCREFQQmdOVkhSTUJBZjhFQlRBREFRSC9NQjBHQTFVZERnUVdCQlMzTERtU3FmVUUKMExzTUF2UWxhd2c1OEtrRkxEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFBWldJNUJHOXNCa0JqTFIzWFlMcwpGcGJrSDlGc283MjYvY1NmN3loVGlkVk5ZVGhKTXBZdXFaM1FReHNnbWVWZm9uUzYyWDlDa2FBeHlkcmpxNDEzCmpxaWwzRmQ4ei93bXRlbFE3N01DM2pPNXl2bzhhZXlwS0ZyUnJ5T0tDbnlDUkY0STBtUUdTakQxcVMySHUxSloKRzVDeCttRHpvRVBQdVY0cGJjSzBlMnhWR2pnNktRUXFTUGtuYkJVRjczVmxqSE5YMmFEYmJITTdoendLbW5MWApPQTY4WnlZSmRyNVhhOE9NZEMxMW8vTW1pK3hlQ2xmbXRjN1RxZGhwNW1ibkpZWFJDRCtLczFVRDg3NVZrTjdrCnI0THVkSXdid1Q4NzV5ZmdwL2NGeGNIOU1HWGlPcmxtZW12bWNuM2NILzZnMjIxbGo1WUVReTgydVZWTlNHblcKNEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+      service:
+        name: istiod
+        namespace: istio-system
+        path: /inject
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: namespace.sidecar-injector.istio.io
+    namespaceSelector:
+      matchExpressions:
+        - key: istio-injection
+          operator: In
+          values:
+            - enabled
+    objectSelector:
+      matchExpressions:
+        - key: sidecar.istio.io/inject
+          operator: NotIn
+          values:
+            - "false"
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+        scope: "*"
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMvVENDQWVXZ0F3SUJBZ0lSQU9LelltVkVTZHM5ODlLd2Z3UmNYK2d3RFFZSktvWklodmNOQVFFTEJRQXcKR0RFV01CUUdBMVVFQ2hNTlkyeDFjM1JsY2k1c2IyTmhiREFlRncweU5UQTBNekF4T1RVMU5EWmFGdzB6TlRBMApNamd4T1RVMU5EWmFNQmd4RmpBVUJnTlZCQW9URFdOc2RYTjBaWEl1Ykc5allXd3dnZ0VpTUEwR0NTcUdTSWIzCkRRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRREV4UFVlcUlHeXFONGQwcVo2MGlVS1djS3dnaEpJSDJKNHp3SVcKUmxacHE0QmFhSThTOHBhTkZvbS9uRjhRaStlQzI3QTc4TXgrbzhtQ1Y3SWVRUG8vMWkxTXY4b3JmRklYQzRocApjNUNGUDNaVkdvMzM2SXVVV3c5ME1yTnNwQ04wRkJLMHhHS3U5aGlpOTloemgwR28vd0VJYlQvb1FyYURaSTdwCk1QNDduc0hFMFFiK2VIeFJrR21PUDA3dkhFWmN6bFpkcCs1RGpxS0ZQdG5mZk1DSXNSSCtKdElqS09hOGZNM1gKcnZEWXpzNnBlL3JMcnk2ZW1IVmcvU2gzeFFHaENvQm1vWW1VVUpRUkZQenNGZVRZbXBpMDd5eis5NlZpeFI0UQp3ZHdib2JwYWFjb0NHZnlqWVAySTlmWEw2WHpVMjUyVTVGOWpFR1pHQUdoSXVHdkxBZ01CQUFHalFqQkFNQTRHCkExVWREd0VCL3dRRUF3SUNCREFQQmdOVkhSTUJBZjhFQlRBREFRSC9NQjBHQTFVZERnUVdCQlMzTERtU3FmVUUKMExzTUF2UWxhd2c1OEtrRkxEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFBWldJNUJHOXNCa0JqTFIzWFlMcwpGcGJrSDlGc283MjYvY1NmN3loVGlkVk5ZVGhKTXBZdXFaM1FReHNnbWVWZm9uUzYyWDlDa2FBeHlkcmpxNDEzCmpxaWwzRmQ4ei93bXRlbFE3N01DM2pPNXl2bzhhZXlwS0ZyUnJ5T0tDbnlDUkY0STBtUUdTakQxcVMySHUxSloKRzVDeCttRHpvRVBQdVY0cGJjSzBlMnhWR2pnNktRUXFTUGtuYkJVRjczVmxqSE5YMmFEYmJITTdoendLbW5MWApPQTY4WnlZSmRyNVhhOE9NZEMxMW8vTW1pK3hlQ2xmbXRjN1RxZGhwNW1ibkpZWFJDRCtLczFVRDg3NVZrTjdrCnI0THVkSXdid1Q4NzV5ZmdwL2NGeGNIOU1HWGlPcmxtZW12bWNuM2NILzZnMjIxbGo1WUVReTgydVZWTlNHblcKNEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+      service:
+        name: istiod
+        namespace: istio-system
+        path: /inject
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: object.sidecar-injector.istio.io
+    namespaceSelector:
+      matchExpressions:
+        - key: istio-injection
+          operator: DoesNotExist
+        - key: istio.io/rev
+          operator: DoesNotExist
+    objectSelector:
+      matchExpressions:
+        - key: sidecar.istio.io/inject
+          operator: In
+          values:
+            - "true"
+        - key: istio.io/rev
+          operator: DoesNotExist
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+        scope: "*"
+    sideEffects: None
+    timeoutSeconds: 10

--- a/tests/data/default-istio-sidecar-injector-mwh.yaml
+++ b/tests/data/default-istio-sidecar-injector-mwh.yaml
@@ -1,0 +1,145 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    app: sidecar-injector
+    app.kubernetes.io/instance: istio
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: istiod
+    app.kubernetes.io/part-of: istio
+    app.kubernetes.io/version: 1.25.0
+    helm.sh/chart: istiod-1.25.0
+    install.operator.istio.io/owning-resource: unknown
+    install.operator.istio.io/owning-resource-namespace: istio-system
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    operator.istio.io/managed: Reconcile
+    operator.istio.io/version: 1.25.0
+    release: istio
+  name: istio-sidecar-injector
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMvVENDQWVXZ0F3SUJBZ0lSQU9LelltVkVTZHM5ODlLd2Z3UmNYK2d3RFFZSktvWklodmNOQVFFTEJRQXcKR0RFV01CUUdBMVVFQ2hNTlkyeDFjM1JsY2k1c2IyTmhiREFlRncweU5UQTBNekF4T1RVMU5EWmFGdzB6TlRBMApNamd4T1RVMU5EWmFNQmd4RmpBVUJnTlZCQW9URFdOc2RYTjBaWEl1Ykc5allXd3dnZ0VpTUEwR0NTcUdTSWIzCkRRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRREV4UFVlcUlHeXFONGQwcVo2MGlVS1djS3dnaEpJSDJKNHp3SVcKUmxacHE0QmFhSThTOHBhTkZvbS9uRjhRaStlQzI3QTc4TXgrbzhtQ1Y3SWVRUG8vMWkxTXY4b3JmRklYQzRocApjNUNGUDNaVkdvMzM2SXVVV3c5ME1yTnNwQ04wRkJLMHhHS3U5aGlpOTloemgwR28vd0VJYlQvb1FyYURaSTdwCk1QNDduc0hFMFFiK2VIeFJrR21PUDA3dkhFWmN6bFpkcCs1RGpxS0ZQdG5mZk1DSXNSSCtKdElqS09hOGZNM1gKcnZEWXpzNnBlL3JMcnk2ZW1IVmcvU2gzeFFHaENvQm1vWW1VVUpRUkZQenNGZVRZbXBpMDd5eis5NlZpeFI0UQp3ZHdib2JwYWFjb0NHZnlqWVAySTlmWEw2WHpVMjUyVTVGOWpFR1pHQUdoSXVHdkxBZ01CQUFHalFqQkFNQTRHCkExVWREd0VCL3dRRUF3SUNCREFQQmdOVkhSTUJBZjhFQlRBREFRSC9NQjBHQTFVZERnUVdCQlMzTERtU3FmVUUKMExzTUF2UWxhd2c1OEtrRkxEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFBWldJNUJHOXNCa0JqTFIzWFlMcwpGcGJrSDlGc283MjYvY1NmN3loVGlkVk5ZVGhKTXBZdXFaM1FReHNnbWVWZm9uUzYyWDlDa2FBeHlkcmpxNDEzCmpxaWwzRmQ4ei93bXRlbFE3N01DM2pPNXl2bzhhZXlwS0ZyUnJ5T0tDbnlDUkY0STBtUUdTakQxcVMySHUxSloKRzVDeCttRHpvRVBQdVY0cGJjSzBlMnhWR2pnNktRUXFTUGtuYkJVRjczVmxqSE5YMmFEYmJITTdoendLbW5MWApPQTY4WnlZSmRyNVhhOE9NZEMxMW8vTW1pK3hlQ2xmbXRjN1RxZGhwNW1ibkpZWFJDRCtLczFVRDg3NVZrTjdrCnI0THVkSXdid1Q4NzV5ZmdwL2NGeGNIOU1HWGlPcmxtZW12bWNuM2NILzZnMjIxbGo1WUVReTgydVZWTlNHblcKNEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+      service:
+        name: istiod
+        namespace: istio-system
+        path: /inject
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: rev.namespace.sidecar-injector.istio.io
+    namespaceSelector:
+      matchLabels:
+        istio.io/deactivated: never-match
+    objectSelector:
+      matchLabels:
+        istio.io/deactivated: never-match
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+        scope: "*"
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMvVENDQWVXZ0F3SUJBZ0lSQU9LelltVkVTZHM5ODlLd2Z3UmNYK2d3RFFZSktvWklodmNOQVFFTEJRQXcKR0RFV01CUUdBMVVFQ2hNTlkyeDFjM1JsY2k1c2IyTmhiREFlRncweU5UQTBNekF4T1RVMU5EWmFGdzB6TlRBMApNamd4T1RVMU5EWmFNQmd4RmpBVUJnTlZCQW9URFdOc2RYTjBaWEl1Ykc5allXd3dnZ0VpTUEwR0NTcUdTSWIzCkRRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRREV4UFVlcUlHeXFONGQwcVo2MGlVS1djS3dnaEpJSDJKNHp3SVcKUmxacHE0QmFhSThTOHBhTkZvbS9uRjhRaStlQzI3QTc4TXgrbzhtQ1Y3SWVRUG8vMWkxTXY4b3JmRklYQzRocApjNUNGUDNaVkdvMzM2SXVVV3c5ME1yTnNwQ04wRkJLMHhHS3U5aGlpOTloemgwR28vd0VJYlQvb1FyYURaSTdwCk1QNDduc0hFMFFiK2VIeFJrR21PUDA3dkhFWmN6bFpkcCs1RGpxS0ZQdG5mZk1DSXNSSCtKdElqS09hOGZNM1gKcnZEWXpzNnBlL3JMcnk2ZW1IVmcvU2gzeFFHaENvQm1vWW1VVUpRUkZQenNGZVRZbXBpMDd5eis5NlZpeFI0UQp3ZHdib2JwYWFjb0NHZnlqWVAySTlmWEw2WHpVMjUyVTVGOWpFR1pHQUdoSXVHdkxBZ01CQUFHalFqQkFNQTRHCkExVWREd0VCL3dRRUF3SUNCREFQQmdOVkhSTUJBZjhFQlRBREFRSC9NQjBHQTFVZERnUVdCQlMzTERtU3FmVUUKMExzTUF2UWxhd2c1OEtrRkxEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFBWldJNUJHOXNCa0JqTFIzWFlMcwpGcGJrSDlGc283MjYvY1NmN3loVGlkVk5ZVGhKTXBZdXFaM1FReHNnbWVWZm9uUzYyWDlDa2FBeHlkcmpxNDEzCmpxaWwzRmQ4ei93bXRlbFE3N01DM2pPNXl2bzhhZXlwS0ZyUnJ5T0tDbnlDUkY0STBtUUdTakQxcVMySHUxSloKRzVDeCttRHpvRVBQdVY0cGJjSzBlMnhWR2pnNktRUXFTUGtuYkJVRjczVmxqSE5YMmFEYmJITTdoendLbW5MWApPQTY4WnlZSmRyNVhhOE9NZEMxMW8vTW1pK3hlQ2xmbXRjN1RxZGhwNW1ibkpZWFJDRCtLczFVRDg3NVZrTjdrCnI0THVkSXdid1Q4NzV5ZmdwL2NGeGNIOU1HWGlPcmxtZW12bWNuM2NILzZnMjIxbGo1WUVReTgydVZWTlNHblcKNEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+      service:
+        name: istiod
+        namespace: istio-system
+        path: /inject
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: rev.object.sidecar-injector.istio.io
+    namespaceSelector:
+      matchLabels:
+        istio.io/deactivated: never-match
+    objectSelector:
+      matchLabels:
+        istio.io/deactivated: never-match
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+        scope: "*"
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMvVENDQWVXZ0F3SUJBZ0lSQU9LelltVkVTZHM5ODlLd2Z3UmNYK2d3RFFZSktvWklodmNOQVFFTEJRQXcKR0RFV01CUUdBMVVFQ2hNTlkyeDFjM1JsY2k1c2IyTmhiREFlRncweU5UQTBNekF4T1RVMU5EWmFGdzB6TlRBMApNamd4T1RVMU5EWmFNQmd4RmpBVUJnTlZCQW9URFdOc2RYTjBaWEl1Ykc5allXd3dnZ0VpTUEwR0NTcUdTSWIzCkRRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRREV4UFVlcUlHeXFONGQwcVo2MGlVS1djS3dnaEpJSDJKNHp3SVcKUmxacHE0QmFhSThTOHBhTkZvbS9uRjhRaStlQzI3QTc4TXgrbzhtQ1Y3SWVRUG8vMWkxTXY4b3JmRklYQzRocApjNUNGUDNaVkdvMzM2SXVVV3c5ME1yTnNwQ04wRkJLMHhHS3U5aGlpOTloemgwR28vd0VJYlQvb1FyYURaSTdwCk1QNDduc0hFMFFiK2VIeFJrR21PUDA3dkhFWmN6bFpkcCs1RGpxS0ZQdG5mZk1DSXNSSCtKdElqS09hOGZNM1gKcnZEWXpzNnBlL3JMcnk2ZW1IVmcvU2gzeFFHaENvQm1vWW1VVUpRUkZQenNGZVRZbXBpMDd5eis5NlZpeFI0UQp3ZHdib2JwYWFjb0NHZnlqWVAySTlmWEw2WHpVMjUyVTVGOWpFR1pHQUdoSXVHdkxBZ01CQUFHalFqQkFNQTRHCkExVWREd0VCL3dRRUF3SUNCREFQQmdOVkhSTUJBZjhFQlRBREFRSC9NQjBHQTFVZERnUVdCQlMzTERtU3FmVUUKMExzTUF2UWxhd2c1OEtrRkxEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFBWldJNUJHOXNCa0JqTFIzWFlMcwpGcGJrSDlGc283MjYvY1NmN3loVGlkVk5ZVGhKTXBZdXFaM1FReHNnbWVWZm9uUzYyWDlDa2FBeHlkcmpxNDEzCmpxaWwzRmQ4ei93bXRlbFE3N01DM2pPNXl2bzhhZXlwS0ZyUnJ5T0tDbnlDUkY0STBtUUdTakQxcVMySHUxSloKRzVDeCttRHpvRVBQdVY0cGJjSzBlMnhWR2pnNktRUXFTUGtuYkJVRjczVmxqSE5YMmFEYmJITTdoendLbW5MWApPQTY4WnlZSmRyNVhhOE9NZEMxMW8vTW1pK3hlQ2xmbXRjN1RxZGhwNW1ibkpZWFJDRCtLczFVRDg3NVZrTjdrCnI0THVkSXdid1Q4NzV5ZmdwL2NGeGNIOU1HWGlPcmxtZW12bWNuM2NILzZnMjIxbGo1WUVReTgydVZWTlNHblcKNEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+      service:
+        name: istiod
+        namespace: istio-system
+        path: /inject
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: namespace.sidecar-injector.istio.io
+    namespaceSelector:
+      matchLabels:
+        istio.io/deactivated: never-match
+    objectSelector:
+      matchLabels:
+        istio.io/deactivated: never-match
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+        scope: "*"
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMvVENDQWVXZ0F3SUJBZ0lSQU9LelltVkVTZHM5ODlLd2Z3UmNYK2d3RFFZSktvWklodmNOQVFFTEJRQXcKR0RFV01CUUdBMVVFQ2hNTlkyeDFjM1JsY2k1c2IyTmhiREFlRncweU5UQTBNekF4T1RVMU5EWmFGdzB6TlRBMApNamd4T1RVMU5EWmFNQmd4RmpBVUJnTlZCQW9URFdOc2RYTjBaWEl1Ykc5allXd3dnZ0VpTUEwR0NTcUdTSWIzCkRRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRREV4UFVlcUlHeXFONGQwcVo2MGlVS1djS3dnaEpJSDJKNHp3SVcKUmxacHE0QmFhSThTOHBhTkZvbS9uRjhRaStlQzI3QTc4TXgrbzhtQ1Y3SWVRUG8vMWkxTXY4b3JmRklYQzRocApjNUNGUDNaVkdvMzM2SXVVV3c5ME1yTnNwQ04wRkJLMHhHS3U5aGlpOTloemgwR28vd0VJYlQvb1FyYURaSTdwCk1QNDduc0hFMFFiK2VIeFJrR21PUDA3dkhFWmN6bFpkcCs1RGpxS0ZQdG5mZk1DSXNSSCtKdElqS09hOGZNM1gKcnZEWXpzNnBlL3JMcnk2ZW1IVmcvU2gzeFFHaENvQm1vWW1VVUpRUkZQenNGZVRZbXBpMDd5eis5NlZpeFI0UQp3ZHdib2JwYWFjb0NHZnlqWVAySTlmWEw2WHpVMjUyVTVGOWpFR1pHQUdoSXVHdkxBZ01CQUFHalFqQkFNQTRHCkExVWREd0VCL3dRRUF3SUNCREFQQmdOVkhSTUJBZjhFQlRBREFRSC9NQjBHQTFVZERnUVdCQlMzTERtU3FmVUUKMExzTUF2UWxhd2c1OEtrRkxEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFBWldJNUJHOXNCa0JqTFIzWFlMcwpGcGJrSDlGc283MjYvY1NmN3loVGlkVk5ZVGhKTXBZdXFaM1FReHNnbWVWZm9uUzYyWDlDa2FBeHlkcmpxNDEzCmpxaWwzRmQ4ei93bXRlbFE3N01DM2pPNXl2bzhhZXlwS0ZyUnJ5T0tDbnlDUkY0STBtUUdTakQxcVMySHUxSloKRzVDeCttRHpvRVBQdVY0cGJjSzBlMnhWR2pnNktRUXFTUGtuYkJVRjczVmxqSE5YMmFEYmJITTdoendLbW5MWApPQTY4WnlZSmRyNVhhOE9NZEMxMW8vTW1pK3hlQ2xmbXRjN1RxZGhwNW1ibkpZWFJDRCtLczFVRDg3NVZrTjdrCnI0THVkSXdid1Q4NzV5ZmdwL2NGeGNIOU1HWGlPcmxtZW12bWNuM2NILzZnMjIxbGo1WUVReTgydVZWTlNHblcKNEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+      service:
+        name: istiod
+        namespace: istio-system
+        path: /inject
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: object.sidecar-injector.istio.io
+    namespaceSelector:
+      matchLabels:
+        istio.io/deactivated: never-match
+    objectSelector:
+      matchLabels:
+        istio.io/deactivated: never-match
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+        scope: "*"
+    sideEffects: None
+    timeoutSeconds: 10

--- a/tests/data/gatherer_namespace_performance_test_config.yaml
+++ b/tests/data/gatherer_namespace_performance_test_config.yaml
@@ -1,0 +1,128 @@
+namespaces:
+  # sets up 500 namespaces with 1500 pods each, in the perf-node-<number> node, where istio injection is defined on the namespace
+  - namePrefix: perf-test-ns-
+    count: 500
+    labels:
+      env: performance
+    isIstioInjected: true
+    hasMetrics: true
+    podConfig:
+      namePrefix: app-pod-
+      count: 1500
+      nodeNamePrefix: perf-node-
+      labels:
+        app: myapp
+      appContainer:
+        cpuRequest: "150m"
+        memRequest: "200Mi"
+        cpuActual: "100m"
+        memActual: "150Mi"
+      istioProxy:
+        cpuRequest: "50m"
+        memRequest: "100Mi"
+        cpuActual: "25m"
+        memActual: "75Mi"
+  
+  # sets up 500 namespaces with 1000 pods each, in the perf-node-2-<number> node, where istio injection is defined on the namespace
+  - namePrefix: perf-test-ns-2-
+    count: 500
+    labels:
+      env: performance
+    isIstioInjected: true
+    hasMetrics: true
+    podConfig:
+      namePrefix: app-pod-2-
+      count: 1000
+      nodeNamePrefix: perf-node-2-
+      labels:
+        app: myapp
+      appContainer:
+        cpuRequest: "150m"
+        memRequest: "200Mi"
+        cpuActual: "100m"
+        memActual: "150Mi"
+      istioProxy:
+        cpuRequest: "50m"
+        memRequest: "100Mi"
+        cpuActual: "25m"
+        memActual: "75Mi"
+
+  # sets up 500 namespaces with 1500 pods each, in the perf-node-<number> node, where istio injection is defined on the pod
+  - namePrefix: perf-test-ns-3-
+    count: 500
+    labels:
+      env: performance
+    isIstioInjected: false
+    hasMetrics: true
+    podConfig:
+      namePrefix: app-pod-injected-
+      count: 1500
+      nodeNamePrefix: perf-node-
+      labels:
+        app: myapp
+        sidecar.istio.io/inject: "true"
+      appContainer:
+        cpuRequest: "150m"
+        memRequest: "200Mi"
+        cpuActual: "100m"
+        memActual: "150Mi"
+      istioProxy:
+        cpuRequest: "50m"
+        memRequest: "100Mi"
+        cpuActual: "25m"
+        memActual: "75Mi"
+  
+  # sets up 250 namespaces with 1500 pods each, in the perf-node-<number> node, where istio injection is not defined
+  - namePrefix: no-istio-ns-
+    count: 250
+    labels:
+      env: no-istio
+    isIstioInjected: false
+    hasMetrics: false
+    podConfig:
+      namePrefix: simple-pod-
+      count: 1500
+      nodeNamePrefix: perf-node-
+      labels:
+        app: simpleapp
+      appContainer:
+        cpuRequest: "50m"
+        memRequest: "64Mi"
+
+  # sets up 250 namespaces with 1500 pods each, in the perf-node-2-<number> node, where istio injection is not defined
+  - namePrefix: no-istio-ns-2-
+    count: 250
+    labels:
+      env: no-istio
+    isIstioInjected: false
+    hasMetrics: false
+    podConfig:
+      namePrefix: simple-pod-2-
+      count: 1500
+      nodeNamePrefix: perf-node-2-
+      labels:
+        app: simpleapp
+      appContainer:
+        cpuRequest: "50m"
+        memRequest: "64Mi"
+
+  # sets up 500 namespaces with 1500 pods each, in the perf-node-3-<number> node, where istio injection is defined on the pod, but is explicitly disabled in the namespace
+  - namePrefix: perf-test-ns-disabled-
+    count: 500
+    labels:
+      env: performance
+      istio-injection: disabled
+    isIstioInjected: false
+    hasMetrics: true
+    podConfig:
+      namePrefix: app-pod-disabled-
+      count: 500
+      nodeNamePrefix: perf-node-3-
+      labels:
+        app: myapp
+        sidecar.istio.io/inject: "true"
+      appContainer:
+        cpuRequest: "150m"
+        memRequest: "200Mi"
+        cpuActual: "100m"
+        memActual: "150Mi"

--- a/tests/data/performance/large_namespaces.yaml
+++ b/tests/data/performance/large_namespaces.yaml
@@ -1,0 +1,87 @@
+namespaces:
+  # sets up 2500 namespaces with 50 pods each, in the perf-node-<number> node, where istio injection is defined on the namespace
+  - namePrefix: perf-test-ns-
+    count: 2500
+    labels:
+      env: performance
+    isIstioInjected: true
+    hasMetrics: true
+    podConfig:
+      namePrefix: app-pod-
+      count: 50
+      nodeNamePrefix: perf-node-
+      labels:
+        app: myapp
+      appContainer:
+        cpuRequest: "150m"
+        memRequest: "200Mi"
+        cpuActual: "100m"
+        memActual: "150Mi"
+      istioProxy:
+        cpuRequest: "50m"
+        memRequest: "100Mi"
+        cpuActual: "25m"
+        memActual: "75Mi"
+
+  # sets up 2500 namespaces with 50 pods each, in the perf-node-<number> node, where istio injection is defined on the pod
+  - namePrefix: perf-test-ns-3-
+    count: 2500
+    labels:
+      env: performance
+    isIstioInjected: false
+    hasMetrics: true
+    podConfig:
+      namePrefix: app-pod-injected-
+      count: 50
+      nodeNamePrefix: perf-node-
+      labels:
+        app: myapp
+        sidecar.istio.io/inject: "true"
+      appContainer:
+        cpuRequest: "150m"
+        memRequest: "200Mi"
+        cpuActual: "100m"
+        memActual: "150Mi"
+      istioProxy:
+        cpuRequest: "50m"
+        memRequest: "100Mi"
+        cpuActual: "25m"
+        memActual: "75Mi"
+  
+  # sets up 2500 namespaces with 10 pods each, in the perf-node-<number> node, where istio injection is not defined
+  - namePrefix: no-istio-ns-
+    count: 2500
+    labels:
+      env: no-istio
+    isIstioInjected: false
+    hasMetrics: false
+    podConfig:
+      namePrefix: simple-pod-
+      count: 10
+      nodeNamePrefix: perf-node-
+      labels:
+        app: simpleapp
+      appContainer:
+        cpuRequest: "50m"
+        memRequest: "64Mi"
+
+  # sets up 1500 namespaces with 25 pods each, in the perf-node-3-<number> node, where istio injection is defined on the pod, but is explicitly disabled in the namespace
+  - namePrefix: perf-test-ns-disabled-
+    count: 1500
+    labels:
+      env: performance
+      istio-injection: disabled
+    isIstioInjected: false
+    hasMetrics: true
+    podConfig:
+      namePrefix: app-pod-disabled-
+      count: 25
+      nodeNamePrefix: perf-node-3-
+      labels:
+        app: myapp
+        sidecar.istio.io/inject: "true"
+      appContainer:
+        cpuRequest: "150m"
+        memRequest: "200Mi"
+        cpuActual: "100m"
+        memActual: "150Mi"

--- a/tests/data/performance/large_pods.yaml
+++ b/tests/data/performance/large_pods.yaml
@@ -1,14 +1,14 @@
 namespaces:
-  # sets up 500 namespaces with 1500 pods each, in the perf-node-<number> node, where istio injection is defined on the namespace
+  # sets up 250 namespaces with 1000 pods each, in the perf-node-<number> node, where istio injection is defined on the namespace
   - namePrefix: perf-test-ns-
-    count: 500
+    count: 250
     labels:
       env: performance
     isIstioInjected: true
     hasMetrics: true
     podConfig:
       namePrefix: app-pod-
-      count: 1500
+      count: 1000
       nodeNamePrefix: perf-node-
       labels:
         app: myapp
@@ -23,9 +23,9 @@ namespaces:
         cpuActual: "25m"
         memActual: "75Mi"
   
-  # sets up 500 namespaces with 1000 pods each, in the perf-node-2-<number> node, where istio injection is defined on the namespace
+  # sets up 250 namespaces with 1000 pods each, in the perf-node-2-<number> node, where istio injection is defined on the namespace
   - namePrefix: perf-test-ns-2-
-    count: 500
+    count: 250
     labels:
       env: performance
     isIstioInjected: true
@@ -47,16 +47,16 @@ namespaces:
         cpuActual: "25m"
         memActual: "75Mi"
 
-  # sets up 500 namespaces with 1500 pods each, in the perf-node-<number> node, where istio injection is defined on the pod
+  # sets up 250 namespaces with 1000 pods each, in the perf-node-<number> node, where istio injection is defined on the pod
   - namePrefix: perf-test-ns-3-
-    count: 500
+    count: 250
     labels:
       env: performance
     isIstioInjected: false
     hasMetrics: true
     podConfig:
       namePrefix: app-pod-injected-
-      count: 1500
+      count: 1000
       nodeNamePrefix: perf-node-
       labels:
         app: myapp
@@ -72,7 +72,7 @@ namespaces:
         cpuActual: "25m"
         memActual: "75Mi"
   
-  # sets up 250 namespaces with 1500 pods each, in the perf-node-<number> node, where istio injection is not defined
+  # sets up 250 namespaces with 1000 pods each, in the perf-node-<number> node, where istio injection is not defined
   - namePrefix: no-istio-ns-
     count: 250
     labels:
@@ -81,7 +81,7 @@ namespaces:
     hasMetrics: false
     podConfig:
       namePrefix: simple-pod-
-      count: 1500
+      count: 1000
       nodeNamePrefix: perf-node-
       labels:
         app: simpleapp
@@ -89,7 +89,7 @@ namespaces:
         cpuRequest: "50m"
         memRequest: "64Mi"
 
-  # sets up 250 namespaces with 1500 pods each, in the perf-node-2-<number> node, where istio injection is not defined
+  # sets up 250 namespaces with 1000 pods each, in the perf-node-2-<number> node, where istio injection is not defined
   - namePrefix: no-istio-ns-2-
     count: 250
     labels:
@@ -98,7 +98,7 @@ namespaces:
     hasMetrics: false
     podConfig:
       namePrefix: simple-pod-2-
-      count: 1500
+      count: 1000
       nodeNamePrefix: perf-node-2-
       labels:
         app: simpleapp
@@ -106,7 +106,7 @@ namespaces:
         cpuRequest: "50m"
         memRequest: "64Mi"
 
-  # sets up 500 namespaces with 1500 pods each, in the perf-node-3-<number> node, where istio injection is defined on the pod, but is explicitly disabled in the namespace
+  # sets up 500 namespaces with 1000 pods each, in the perf-node-3-<number> node, where istio injection is defined on the pod, but is explicitly disabled in the namespace
   - namePrefix: perf-test-ns-disabled-
     count: 500
     labels:
@@ -116,7 +116,7 @@ namespaces:
     hasMetrics: true
     podConfig:
       namePrefix: app-pod-disabled-
-      count: 500
+      count: 1000
       nodeNamePrefix: perf-node-3-
       labels:
         app: myapp

--- a/tests/e2e/istio_global_injection_test.go
+++ b/tests/e2e/istio_global_injection_test.go
@@ -1,0 +1,78 @@
+//go:build test || e2e
+
+package e2e
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/solo-io/istio-usage-collector/internal/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+// IstioGlobalInjectionTestSuite defines the main structure for our E2E tests
+type IstioGlobalInjectionTestSuite struct {
+	BaseTestSuite
+	clusterName   string
+	metricsServer bool
+}
+
+// SetupSuite runs once before all tests in the suite.
+func (s *IstioGlobalInjectionTestSuite) SetupSuite() {
+	s.clusterName = "e2e-istio-global-injection-test-cluster"
+	s.metricsServer = false
+	// using values to enable namespace-level injection by default (no explicit istio-injection label required)
+	s.istioValuesPath = "testdata/input/istio-values-default-injection.yaml"
+	s.SetupBase(s.T(), s.clusterName, s.metricsServer)
+}
+
+// TearDownSuite runs once after all tests in the suite have finished.
+func (s *IstioGlobalInjectionTestSuite) TearDownSuite() {
+	s.TearDownBase(s.T(), s.clusterName)
+}
+
+// TestE2ERunner is the entry point for running the suite.
+func TestIstioGlobalInjectionTestSuiteRunner(t *testing.T) {
+	suite.Run(t, new(IstioGlobalInjectionTestSuite))
+}
+
+// Example test case structure
+func (s *IstioGlobalInjectionTestSuite) TestIstioGlobalInjectionJSONOutput() {
+	require := s.Require() // Use require for assertions within the test
+
+	// --- Test Setup ---
+	inputManifest := "testdata/input/istio-global-injection-manifest.yaml"
+	expectedOutputFile := "./testdata/output/istio-global-injection-expected.json"
+
+	// create temporary directory for output
+	testOutputDir, err := os.MkdirTemp("", "istio-usage-collector-e2e-test")
+	require.NoError(err, "Failed to create temporary directory for output")
+	defer os.RemoveAll(testOutputDir)
+
+	// --- Apply Input Manifests ---
+	s.T().Logf("Applying input manifest: %s", inputManifest)
+	applyKubectl(s.T(), s.kubeconfigPath, inputManifest)
+
+	// --- Run the Main Binary ---
+	s.T().Log("Running main binary...")
+	config := utils.Config{
+		ObfuscateNames: false,
+		NoProgress:     true, // Disabled for cleaner test logs
+		OutputDir:      testOutputDir,
+		// Not necessary, but for the ease of testing (finding exact output file), setting these values
+		OutputFormat:     "json",
+		OutputFilePrefix: "output",
+	}
+
+	assert.Eventually(s.T(), func() bool {
+		actualOutputFile := runMainBinary(s.T(), config)
+		if err := compareFiles(actualOutputFile, expectedOutputFile); err != nil {
+			s.T().Logf("Output comparison failed: %v", err)
+			return false
+		}
+
+		return true
+	}, 30*time.Second, 100*time.Millisecond, "Output comparison failed")
+}

--- a/tests/e2e/pod_test.go
+++ b/tests/e2e/pod_test.go
@@ -1,0 +1,76 @@
+//go:build test || e2e
+
+package e2e
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/solo-io/istio-usage-collector/internal/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+// PodTestSuite defines the main structure for our E2E tests
+type PodTestSuite struct {
+	BaseTestSuite
+	clusterName   string
+	metricsServer bool
+}
+
+// SetupSuite runs once before all tests in the suite.
+func (s *PodTestSuite) SetupSuite() {
+	s.clusterName = "e2e-pod-test-cluster"
+	s.metricsServer = false
+	s.SetupBase(s.T(), s.clusterName, s.metricsServer)
+}
+
+// TearDownSuite runs once after all tests in the suite have finished.
+func (s *PodTestSuite) TearDownSuite() {
+	s.TearDownBase(s.T(), s.clusterName)
+}
+
+// TestE2ERunner is the entry point for running the suite.
+func TestPodTestSuiteRunner(t *testing.T) {
+	suite.Run(t, new(PodTestSuite))
+}
+
+// Example test case structure
+func (s *PodTestSuite) TestPodJSONOutput() {
+	require := s.Require() // Use require for assertions within the test
+
+	// --- Test Setup ---
+	inputManifest := "testdata/input/pod-manifest.yaml"
+	expectedOutputFile := "./testdata/output/pod-expected.json"
+
+	// create temporary directory for output
+	testOutputDir, err := os.MkdirTemp("", "istio-usage-collector-e2e-test")
+	require.NoError(err, "Failed to create temporary directory for output")
+	defer os.RemoveAll(testOutputDir)
+
+	// --- Apply Input Manifests ---
+	s.T().Logf("Applying input manifest: %s", inputManifest)
+	applyKubectl(s.T(), s.kubeconfigPath, inputManifest)
+
+	// --- Run the Main Binary ---
+	s.T().Log("Running main binary...")
+	config := utils.Config{
+		ObfuscateNames: false,
+		NoProgress:     true, // Disabled for cleaner test logs
+		OutputDir:      testOutputDir,
+		// Not necessary, but for the ease of testing (finding exact output file), setting these values
+		OutputFormat:     "json",
+		OutputFilePrefix: "output",
+	}
+
+	assert.Eventually(s.T(), func() bool {
+		actualOutputFile := runMainBinary(s.T(), config)
+		if err := compareFiles(actualOutputFile, expectedOutputFile); err != nil {
+			s.T().Logf("Output comparison failed: %v", err)
+			return false
+		}
+
+		return true
+	}, 30*time.Second, 100*time.Millisecond, "Output comparison failed")
+}

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -23,7 +23,9 @@ func (b *BaseTestSuite) SetupBase(t *testing.T, clusterName string, metricsServe
 	t.Logf("Using kubeconfig: %s", b.kubeconfigPath)
 
 	// Install Istio
-	b.istioValuesPath = "testdata/input/istio-values.yaml"
+	if b.istioValuesPath == "" {
+		b.istioValuesPath = "testdata/input/istio-values.yaml"
+	}
 	installIstio(t, b.kubeconfigPath, b.istioValuesPath)
 
 	// Optionally install Metrics Server

--- a/tests/e2e/testdata/input/istio-global-injection-manifest.yaml
+++ b/tests/e2e/testdata/input/istio-global-injection-manifest.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: namespace-1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-1
+  namespace: namespace-1
+spec:
+  containers:
+  - name: nginx
+    image: nginx:latest
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi

--- a/tests/e2e/testdata/input/istio-values-default-injection.yaml
+++ b/tests/e2e/testdata/input/istio-values-default-injection.yaml
@@ -1,0 +1,30 @@
+global:
+  proxy:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+
+# Settings specific to the istiod deployment
+pilot:
+  autoscaleEnabled: false
+  k8s:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 2048Mi
+
+gateways:
+  istio-ingressgateway:
+    enabled: false
+  istio-egressgateway:
+    enabled: false
+
+sidecarInjectorWebhook:
+  enableNamespacesByDefault: true
+
+# Use default revision
+revision: ""

--- a/tests/e2e/testdata/input/pod-manifest.yaml
+++ b/tests/e2e/testdata/input/pod-manifest.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: namespace-1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-1
+  namespace: namespace-1
+spec:
+  containers:
+  - name: nginx
+    image: nginx:latest
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: istio-injected-pod-1
+  namespace: namespace-1
+  labels:
+    sidecar.istio.io/inject: "true"
+spec:
+  containers:
+  - name: nginx
+    image: nginx:latest
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi

--- a/tests/e2e/testdata/output/istio-global-injection-expected.json
+++ b/tests/e2e/testdata/output/istio-global-injection-expected.json
@@ -1,0 +1,49 @@
+{
+    "name": "kind-e2e-istio-global-injection-test-cluster",
+    "namespaces": {
+      "default": {
+        "is_istio_injected": false,
+        "pods": 0,
+        "resources": {
+          "regular": {
+            "containers": 0,
+            "request": {
+              "cpu": 0,
+              "memory_gb": 0
+            }
+          }
+        }
+      },
+      "namespace-1": {
+        "is_istio_injected": true,
+        "pods": 1,
+        "resources": {
+          "regular": {
+            "containers": 1,
+            "request": {
+              "cpu": 0.1,
+              "memory_gb": 0.09765625
+            }
+          },
+          "istio": {
+            "containers": 1,
+            "request": {
+              "cpu": 0.1,
+              "memory_gb": 0.125
+            }
+          }
+        }
+      }
+    },
+    "nodes": {
+      "e2e-istio-global-injection-test-cluster-control-plane": {
+        "instance_type": "unknown",
+        "region": "unknown",
+        "zone": "unknown",
+        "resources": {
+          "capacity": {}
+        }
+      }
+    },
+    "has_metrics": false
+  } 

--- a/tests/e2e/testdata/output/pod-expected.json
+++ b/tests/e2e/testdata/output/pod-expected.json
@@ -1,0 +1,49 @@
+{
+    "name": "kind-e2e-pod-test-cluster",
+    "namespaces": {
+      "default": {
+        "is_istio_injected": false,
+        "pods": 0,
+        "resources": {
+          "regular": {
+            "containers": 0,
+            "request": {
+              "cpu": 0,
+              "memory_gb": 0
+            }
+          }
+        }
+      },
+      "namespace-1": {
+        "is_istio_injected": true,
+        "pods": 2,
+        "resources": {
+          "regular": {
+            "containers": 2,
+            "request": {
+              "cpu": 0.2,
+              "memory_gb": 0.1953125
+            }
+          },
+          "istio": {
+            "containers": 1,
+            "request": {
+              "cpu": 0.1,
+              "memory_gb": 0.125
+            }
+          }
+        }
+      }
+    },
+    "nodes": {
+      "e2e-pod-test-cluster-control-plane": {
+        "instance_type": "unknown",
+        "region": "unknown",
+        "zone": "unknown",
+        "resources": {
+          "capacity": {}
+        }
+      }
+    },
+    "has_metrics": false
+  } 

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -1,0 +1,109 @@
+package tests
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
+)
+
+// Helper function to create a simple pod
+func NewPod(namespace, name, nodeName string, cpuRequest, memRequest string, hasIstioProxy bool, istioProxyCpu, istioProxyMem string, labels map[string]string) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+			Containers: []corev1.Container{
+				{
+					Name: "app",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{},
+					},
+				},
+			},
+		},
+	}
+	if cpuRequest != "" {
+		pod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse(cpuRequest)
+	}
+	if memRequest != "" {
+		pod.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory] = resource.MustParse(memRequest)
+	}
+
+	if hasIstioProxy {
+		istioContainer := corev1.Container{
+			Name: "istio-proxy",
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse(istioProxyCpu),
+					corev1.ResourceMemory: resource.MustParse(istioProxyMem),
+				},
+			},
+		}
+		pod.Spec.Containers = append(pod.Spec.Containers, istioContainer)
+	}
+	return pod
+}
+
+// Helper function to create pod metrics
+func NewPodMetrics(namespace, name string, cpuUsage, memUsage string, hasIstioProxy bool, istioCpuUsage, istioMemUsage string) *v1beta1.PodMetrics {
+	metrics := &v1beta1.PodMetrics{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Containers: []v1beta1.ContainerMetrics{
+			{
+				Name: "app",
+				Usage: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse(cpuUsage),
+					corev1.ResourceMemory: resource.MustParse(memUsage),
+				},
+			},
+		},
+	}
+	if hasIstioProxy {
+		istioMetrics := v1beta1.ContainerMetrics{
+			Name: "istio-proxy",
+			Usage: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(istioCpuUsage),
+				corev1.ResourceMemory: resource.MustParse(istioMemUsage),
+			},
+		}
+		metrics.Containers = append(metrics.Containers, istioMetrics)
+	}
+	return metrics
+}
+
+// Helper function to create a simple node
+func NewNode(name, cpuCapacity, memCapacity string, labels map[string]string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Status: corev1.NodeStatus{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(cpuCapacity),
+				corev1.ResourceMemory: resource.MustParse(memCapacity),
+			},
+		},
+	}
+}
+
+// Helper function to create node metrics
+func NewNodeMetrics(name, cpuUsage, memUsage string) *v1beta1.NodeMetrics {
+	return &v1beta1.NodeMetrics{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Usage: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(cpuUsage),
+			corev1.ResourceMemory: resource.MustParse(memUsage),
+		},
+	}
+}


### PR DESCRIPTION
_resolves https://github.com/solo-io/istio-usage-collector/issues/8_

# Changes

- Added a flag to disable the auto-processor, specifically by manually setting amount of processes.
  - This was initially added for the benchmarks to make it easier to see one-by-one processes, although kept as a nice-to-have. 
  - By default (or <= 0) we will use the existing amount of processes, else we'll use the input.
- We've moved to checking if istio containers are injection based on the mutating webhooks that Istio manages which define when to (auto) inject containers into a pod. 
- We are also now only stating if a namespace `is_istio_injected` _iff_ it contains a pod which is injected by istio. 
    - This simplified things like validating between namespace-level enablement & pod-level (& global), where we can simply base it on this new granular pod-level, mutatingwebhook (which accounts for global), check. 
    - The negative side of this approach is that we don't count _manually_ injected proxies as part of Istio resources as they do not follow the usual labeling+mwh. I've added a debug log for this edge case. Also note that this behavior is similar as before, although now "officially" known and logged.

## Context

Previously we were only checking for istio injection on a namespace-level. This means if a namespace did not have istio injection **but** a pod did have injection, we would ignore it, state the namespace did not have injection, and didn't propagate the pod-level data. A similar thing occurred if the global policy for injection (`values.sidecarInjectorWebhook.enableNamespacesByDefault`) was enabled, and the namespaces/pods didn't have the enablement label.

# Performance

Because of the added overhead of checking webooks per-pod (to check if automatic istio injection is enabled), we expect performance to be degraded. I’ve added some performance tests - unused by CI checks - to get a general idea of the impact we may see. I’ve only ran for the `processNamespaces`, which is what would be affected by these changes.

These tests run using the default istio webhooks (from running `istioctl install`). The performance hit with these changes becomes more noticeable in environments with _more_ Istio mutating webhooks. I'm unsure what other configurations/permutations exist for these webhooks - aside from an extra webhook being added when global namespace injection is enabled.

## Benchmark

goos: darwin
goarch: arm64
pkg: github.com/solo-io/istio-usage-collector/internal/gatherer
cpu: Apple M4 Max

### Before

```
LargeNamespaces_MultiProcessor:
  Namespaces Processed: 9000
  Pods Processed: 312500
  Duration: 1m8.827415667s
LargeNamespaces_SingleProcessor:
  Namespaces Processed: 9000
  Pods Processed: 312500
  Duration: 1m24.908139583s

LargePods_MultiProcessor:
  Namespaces Processed: 1750
  Pods Processed: 1750000
  Duration: 1m34.023948375s
LargePods_SingleProcessor:
  Namespaces Processed: 1750
  Pods Processed: 1750000
  Duration: 1m44.28450625s
```

### After

```
LargeNamespaces_MultiProcessor:
  Namespaces Processed: 9000
  Pods Processed: 312500
  Duration: 1m8.836110667s
LargeNamespaces_SingleProcessor:
  Namespaces Processed: 9000
  Pods Processed: 312500
  Duration: 1m25.535298541s

LargePods_MultiProcessor:
  Namespaces Processed: 1750
  Pods Processed: 1750000
  Duration: 1m28.926342459s
LargePods_SingleProcessor:
  Namespaces Processed: 1750
  Pods Processed: 1750000
  Duration: 1m58.991332291s
```

## Optimizations

It should be possible to optimize this. For instance, when we do a `CheckInject` we process data for the namespace and pod. Because we run this on a per-pod basis, where we do {namespace -> pods}, it should be possible to pre-process information for namespace and send that to the `CheckInject` to avoid re-processing namespace information. I tried doing this, but it would require some more extensive testing to ensure it works as expected.

I opened an issue for this optimization with an untested WIP PR attached. https://github.com/solo-io/istio-usage-collector/issues/9

TODO:
- [x] licensing information, as we're copying portions of the istioctl injection check for this (although modified for our purposes) https://github.com/istio/istio/blob/master/istioctl/pkg/checkinject/checkinject.go
    - exists - https://docs.solo.io/gloo-mesh-enterprise/latest/reference/version/osa/
- [x] look into performance tests
    - Not running in CI at least now to get this out sooner and not spend time finding the optimal time and delta based on runner(s). For now it's meant for _local_ running.